### PR TITLE
Restructure library and make MQTT topic optional

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,6 +4,9 @@ about: Create a report to help us improve
 
 ---
 
+**ecowitt2mqtt version**
+Provide the version you are currently using.
+
 **Describe the bug**
 A clear and concise description of what the bug is.
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,11 +4,8 @@ about: Suggest an idea for this project
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+**ecowitt2mqtt version**
+Provide the version you are currently using.
 
 **Describe the solution you'd like**
 A clear and concise description of what you want to happen.
-
-**Additional context**
-Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,5 @@ Fixes https://github.com/bachya/ecowitt2mqtt/issues/<ISSUE ID>
   
 **Checklist:**
 
-- [ ] Confirm that one or more new tests are written for the new functionality.
-- [ ] Run tests and ensure everything passes (with 100% test coverage).
 - [ ] Update `README.md` with any new documentation.
 - [ ] Add yourself to `AUTHORS.md`.

--- a/README.md
+++ b/README.md
@@ -69,11 +69,9 @@ $ ecowitt2mqtt \
     --mqtt-broker=192.168.1.101 \
     --mqtt-username=user \
     --mqtt-password=password \
-    --mqtt-topic=ecowitt/testdevice1
 ```
 
-Within the `Upload Interval`, data should begin to appear in the MQTT broker at the topic
-specified.
+Within the `Upload Interval`, data should begin to appear in the MQTT broker.
 
 # Advanced Usage
 
@@ -91,14 +89,14 @@ optional arguments:
   -h, --help            show this help message and exit
   --mqtt-broker MQTT_BROKER
                         The hostname or IP address of the MQTT broker
-  --mqtt-topic MQTT_TOPIC
-                        The MQTT topic to publish the device's data to
   --mqtt-port MQTT_PORT
                         The port of the MQTT broker (default: 1883)
   --mqtt-username MQTT_USERNAME
                         The username to use with the MQTT broker (default: None)
   --mqtt-password MQTT_PASSWORD
                         The password to use with the MQTT broker (default: None)
+  --mqtt-topic MQTT_TOPIC
+                        The MQTT topic to publish the device's data to (default: ecowitt2mqtt/<ID>)
   --endpoint ENDPOINT   The relative endpoint/path to serve the web app on (default: /data/report)
   --port PORT           The port to serve the web app on (default: 8080)
   -l LOG_LEVEL, --log-level LOG_LEVEL
@@ -117,7 +115,7 @@ loglevel=info
 user=root
 
 [program:ecowitt2mqtt]
-command=ecowitt2mqtt --mqtt-broker=192.168.1.101 --mqtt-topic=ecowitt/testdevice1
+command=ecowitt2mqtt --mqtt-broker=192.168.1.101 --mqtt-username=user --mqtt-password=password
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 redirect_stderr=true
@@ -146,7 +144,6 @@ docker run -it \
     -e MQTT_BROKER=192.168.1.101 \
     -e MQTT_USERNAME=user \
     -e MQTT_PASSWORD=password \
-    -e MQTT_TOPIC=ecowitt/testdevice1 \
     -p 8080:8080 \
     bachya/ecowitt2mqtt:latest
 ```

--- a/ecowitt2mqtt/const.py
+++ b/ecowitt2mqtt/const.py
@@ -1,0 +1,4 @@
+"""Define constants."""
+import logging
+
+LOGGER = logging.getLogger("ecowitt2mqtt")

--- a/ecowitt2mqtt/mqtt.py
+++ b/ecowitt2mqtt/mqtt.py
@@ -1,0 +1,57 @@
+"""Define MQTT functionality."""
+import json
+from typing import Optional
+
+from asyncio_mqtt import Client, MqttError
+from ecowitt2mqtt.const import LOGGER
+
+DEFAULT_MQTT_PORT = 1883
+DEFAULT_TOPIC_TEMPLATE = "ecowitt2mqtt/{0}"
+
+
+class MQTT:
+    """Define an MQTT manager."""
+
+    def __init__(
+        self,
+        broker: str,
+        *,
+        port: int = DEFAULT_MQTT_PORT,
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+        topic: Optional[str] = None
+    ) -> None:
+        """Initialize."""
+        self._client = Client(broker, port=port, username=username, password=password)
+        self._topic = topic
+
+    async def async_connect(self) -> None:
+        """Connect to the MQTT broker."""
+        try:
+            await self._client.connect()
+        except MqttError as err:
+            LOGGER.error("Error while connecting to MQTT broker: %s", err)
+
+        LOGGER.debug("Connected to MQTT broker")
+
+    async def async_disconnect(self) -> None:
+        """Disconnect from the MQTT broker."""
+        try:
+            await self._client.disconnect()
+        except MqttError as err:
+            LOGGER.error("Error while disconnecting from MQTT broker: %s", err)
+
+        LOGGER.debug("Disconnected from MQTT broker")
+
+    async def async_publish_topic(self, data: dict) -> None:
+        """Publish data to an MQTT topic."""
+        if self._topic:
+            topic = self._topic
+        else:
+            topic = DEFAULT_TOPIC_TEMPLATE.format(data["PASSKEY"])
+
+        try:
+            await self._client.publish(topic, json.dumps(dict(data)).encode())
+            LOGGER.info("Data published to topic %s: %s", topic, data)
+        except MqttError as err:
+            LOGGER.error("Error while publishing data to MQTT: %s", err)

--- a/ecowitt2mqtt/routes.py
+++ b/ecowitt2mqtt/routes.py
@@ -1,0 +1,12 @@
+"""Define aiohttp routes."""
+from aiohttp import web
+from ecowitt2mqtt.const import LOGGER
+
+
+async def respond_to_ecowitt_data(request: web.Request):
+    """Define the endpoint for the Ecowitt device to post data to."""
+    data = await request.post()
+
+    LOGGER.debug("Received data from Ecowitt device: %s", data)
+
+    await request.app["mqtt"].async_publish_topic(data)


### PR DESCRIPTION
**Describe what the PR does:**

This PR restructures the library internally so that future growth is more possible. In so doing, `mqtt-topic` is now optional; by default, data will be sent to `ecowitt2mqtt/<DEVICE ID>`.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
