### PR TITLE
Ensure HASS MQTT Discovery tasks are done efficiently

### DIFF
--- a/ecowitt2mqtt/routes.py
+++ b/ecowitt2mqtt/routes.py
@@ -45,12 +45,12 @@ async def async_respond_to_ecowitt_data(request: web.Request):
         else:
             discovery = hass_discovery_managers[unique_id] = HassDiscovery(unique_id)
 
+    tasks = []
     for key, value in data.items():
         config_payload = discovery.get_config_payload(key)
         config_topic = discovery.get_config_topic(key)
-        tasks = [
-            mqtt.async_publish(config_topic, config_payload),
-            mqtt.async_publish(config_payload["availability_topic"], "online"),
-            mqtt.async_publish(config_payload["state_topic"], value),
-        ]
-        await asyncio.gather(*tasks)
+        tasks.append(mqtt.async_publish(config_topic, config_payload))
+        tasks.append(mqtt.async_publish(config_payload["availability_topic"], "online"))
+        tasks.append(mqtt.async_publish(config_payload["state_topic"], value))
+
+    await asyncio.gather(*tasks)


### PR DESCRIPTION
**Describe what the PR does:**

Previously, HASS MQTT Discovery was publishing sets of three topics individually, one for each sensor. This PR updates things to fire all the "publish tasks" at once.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
