### PR TITLE
Add support for pressure values in metric

### DIFF
--- a/ecowitt2mqtt/const.py
+++ b/ecowitt2mqtt/const.py
@@ -6,7 +6,9 @@ LOGGER = logging.getLogger(__package__)
 # Possible data points:
 DATA_POINT_24HOURRAIN = "24hourrain"
 DATA_POINT_24HOURRAININ = "24hourrainin"
+DATA_POINT_BAROMABS = "baromabs"
 DATA_POINT_BAROMABSIN = "baromabsin"
+DATA_POINT_BAROMREL = "baromrel"
 DATA_POINT_BAROMRELIN = "baromrelin"
 DATA_POINT_CO2 = "co2"
 DATA_POINT_DAILYRAIN = "dailyrain"


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds support for pressure values in metric.

This is technically a breaking change, as it modifies the data keys that were previously used – for instance, `baromabsin` is converted to `baromabs`. This is done in order to not produce double of every field (an imperial variant and a metric variant).

**Does this fix a specific issue?**

Addresses part of  https://github.com/bachya/ecowitt2mqtt/issues/12
  
**Checklist:**

- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
