### PR TITLE
Fix ValueError in pressure data conversion

### DIFF
--- a/ecowitt2mqtt/data.py
+++ b/ecowitt2mqtt/data.py
@@ -205,7 +205,9 @@ class DataProcessor:  # pylint: disable=too-many-instance-attributes
                 continue
 
             if self._unit_system == UNIT_SYSTEM_METRIC:
-                data[new_key] = round(inhg_to_hpa(int(self._data[original_key])), 1)
+                data[new_key] = round(
+                    inhg_to_hpa(int(float(self._data[original_key]))), 1
+                )
             else:
                 data[new_key] = int(self._data[original_key])
 


### PR DESCRIPTION
**Describe what the PR does:**

This PR fixes an improper `int` conversion when converting pressure data.

**Does this fix a specific issue?**

Fixes https://github.com/bachya/ecowitt2mqtt/issues/32
  
**Checklist:**

- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
