### PR TITLE
Don't explicitly install OpenSSL when building Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ COPY requirements.txt /tmp/requirements.txt
 RUN apk add --no-cache --virtual build-dependencies \
       build-base==0.5-r2 \
       libffi-dev==3.3-r2 \
-      openssl-dev==1.1.1g-r0 \
     && apk add --no-cache \
       bash==5.0.17-r0 \
     && pip3 install -r /tmp/requirements.txt \


### PR DESCRIPTION
**Describe what the PR does:**

This PR removes an explicit OpenSSL installation instruction in the Dockerfile, which was preventing the image from building.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
