### PR TITLE
Use empty string for sensors without units

### DIFF
--- a/ecowitt2mqtt/hass.py
+++ b/ecowitt2mqtt/hass.py
@@ -198,7 +198,7 @@ class HassDiscovery:  # pylint: disable=too-few-public-methods
                 unit = UNIT_MAPPING[data_class][self._unit_system]
         else:
             icon = DEFAULT_ICON
-            unit = None
+            unit = ""
 
         self._config_payloads[key] = {
             "availability_topic": self._get_topic(key, "availability"),


### PR DESCRIPTION
**Describe what the PR does:**

Home Assistant MQTT Discovery will choke when a topic has a unit-of-measurement of `None`, so this PR changes the default value to be an empty string.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
