### PR TITLE
Upgrade aiohttp to a minimum of 3.7.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-aiohttp = "^3.6.2"
+aiohttp = "^3.7.4"
 asyncio-mqtt = "^0.7.0"
 meteocalc = "^1.1.0"
 python = "^3.6.1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-aiohttp==3.6.2
+aiohttp>=3.7.4
 asyncio-mqtt==0.7.0
 meteocalc==1.1.0


### PR DESCRIPTION
**Describe what the PR does:**

This PR upgrades `aiohttp` to 3.7.4, which fixes https://github.com/advisories/GHSA-v6wp-4m6f-gcjg.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
