### PR TITLE
Add support for multiple Home Assistant MQTT Discovery components

### DIFF
--- a/ecowitt2mqtt/hass.py
+++ b/ecowitt2mqtt/hass.py
@@ -12,10 +12,12 @@ from ecowitt2mqtt.const import (
     DATA_POINT_UV,
     DATA_POINT_WINDCHILL,
     DATA_POINT_WINDDIR,
-    LOGGER,
     UNIT_SYSTEM_IMPERIAL,
     UNIT_SYSTEM_METRIC,
 )
+
+COMPONENT_BINARY_SENSOR = "binary_sensor"
+COMPONENT_SENSOR = "sensor"
 
 DEFAULT_DISCOVERY_PREFIX = "homeassistant"
 DEFAULT_ICON = "mdi:server"
@@ -28,26 +30,56 @@ UNIT_CLASS_TEMPERATURE = "temperature"
 UNIT_CLASS_WIND = "wind"
 
 GLOB_DATA_POINTS = {
-    "barom": ("mdi:cloud", None, UNIT_CLASS_PRESSURE, None),
-    "gust": ("mdi:weather-windy", None, UNIT_CLASS_WIND, None),
-    "humidity": ("mdi:water-percent", None, None, "%"),
-    "moisture": ("mdi:water-percent", None, None, "%"),
-    "rain": ("mdi:water", None, UNIT_CLASS_RAIN, None),
-    "temp": ("mdi:thermometer", None, UNIT_CLASS_TEMPERATURE, None),
-    "wind": ("mdi:weather-windy", None, UNIT_CLASS_WIND, None),
+    "barom": (COMPONENT_SENSOR, "mdi:cloud", None, UNIT_CLASS_PRESSURE, None),
+    "gust": (COMPONENT_SENSOR, "mdi:weather-windy", None, UNIT_CLASS_WIND, None),
+    "humidity": (COMPONENT_SENSOR, "mdi:water-percent", None, None, "%"),
+    "moisture": (COMPONENT_SENSOR, "mdi:water-percent", None, None, "%"),
+    "rain": (COMPONENT_SENSOR, "mdi:water", None, UNIT_CLASS_RAIN, None),
+    "temp": (COMPONENT_SENSOR, "mdi:thermometer", None, UNIT_CLASS_TEMPERATURE, None),
+    "wind": (COMPONENT_SENSOR, "mdi:weather-windy", None, UNIT_CLASS_WIND, None),
 }
 
 SPECIFIC_DATA_POINTS = {
-    DATA_POINT_CO2: ("mdi:molecule-co", None, None, "ppm"),
-    DATA_POINT_DEWPOINT: ("mdi:thermometer", None, UNIT_CLASS_TEMPERATURE, None),
-    DATA_POINT_FEELSLIKE: ("mdi:thermometer", None, UNIT_CLASS_TEMPERATURE, None),
-    DATA_POINT_HEATINDEX: ("mdi:thermometer", None, UNIT_CLASS_TEMPERATURE, None),
-    DATA_POINT_PM25: ("mdi:biohazard", None, None, "µg/m^3"),
-    DATA_POINT_PM25_24H: ("mdi:biohazard", None, None, "µg/m^3"),
-    DATA_POINT_SOLARRADIATION: ("mdi:weather-sunny", None, None, "w/m^2"),
-    DATA_POINT_UV: ("mdi:weather-sunny", None, None, "UV index"),
-    DATA_POINT_WINDCHILL: ("mdi:weather-windy", None, UNIT_CLASS_TEMPERATURE, None),
-    DATA_POINT_WINDDIR: ("mdi:weather-windy", None, None, "°"),
+    DATA_POINT_CO2: (COMPONENT_SENSOR, "mdi:molecule-co", None, None, "ppm"),
+    DATA_POINT_DEWPOINT: (
+        COMPONENT_SENSOR,
+        "mdi:thermometer",
+        None,
+        UNIT_CLASS_TEMPERATURE,
+        None,
+    ),
+    DATA_POINT_FEELSLIKE: (
+        COMPONENT_SENSOR,
+        "mdi:thermometer",
+        None,
+        UNIT_CLASS_TEMPERATURE,
+        None,
+    ),
+    DATA_POINT_HEATINDEX: (
+        COMPONENT_SENSOR,
+        "mdi:thermometer",
+        None,
+        UNIT_CLASS_TEMPERATURE,
+        None,
+    ),
+    DATA_POINT_PM25: (COMPONENT_SENSOR, "mdi:biohazard", None, None, "µg/m^3"),
+    DATA_POINT_PM25_24H: (COMPONENT_SENSOR, "mdi:biohazard", None, None, "µg/m^3"),
+    DATA_POINT_SOLARRADIATION: (
+        COMPONENT_SENSOR,
+        "mdi:weather-sunny",
+        None,
+        None,
+        "w/m^2",
+    ),
+    DATA_POINT_UV: (COMPONENT_SENSOR, "mdi:weather-sunny", None, None, "UV index"),
+    DATA_POINT_WINDCHILL: (
+        COMPONENT_SENSOR,
+        "mdi:weather-windy",
+        None,
+        UNIT_CLASS_TEMPERATURE,
+        None,
+    ),
+    DATA_POINT_WINDDIR: (COMPONENT_SENSOR, "mdi:weather-windy", None, None, "°"),
 }
 
 UNIT_MAPPING = {
@@ -60,12 +92,12 @@ UNIT_MAPPING = {
 
 def get_data_point_characteristics(
     key: str,
-) -> Tuple[str, Optional[str], Optional[str], Optional[str]]:
+) -> Tuple[str, str, Optional[str], Optional[str], Optional[str]]:
     """Get a data point's characteristics.
 
     1. Return a specific data point if it exists.
     2. Return a globbed data point if it exists.
-    3. Raise if nothing exists
+    3. Return defaults if no specific or globbed data points exist.
     """
     if key in SPECIFIC_DATA_POINTS:
         return SPECIFIC_DATA_POINTS[key]
@@ -74,13 +106,14 @@ def get_data_point_characteristics(
     if matches:
         return matches[0]
 
-    return (DEFAULT_ICON, None, None, None)
+    return (COMPONENT_SENSOR, DEFAULT_ICON, None, None, None)
 
 
 class ConfigPayloadType(TypedDict):
     """Define a type for a config payload."""
 
     availability_topic: str
+    config_topic: str
     device_class: Optional[str]
     icon: str
     name: str
@@ -102,37 +135,42 @@ class HassDiscovery:  # pylint: disable=too-few-public-methods
     ) -> None:
         """Initialize."""
         self._config_payloads: Dict[str, ConfigPayloadType] = {}
-        self._discovery_prefix = discovery_prefix
+        self._config_topics: Dict[str, str] = {}
+        self._prefix = discovery_prefix
         self._unique_id = unique_id
         self._unit_system = unit_system
 
-    def _get_topic(self, key: str, topic_type: str) -> str:
+    def _get_topic(self, key: str, component: str, topic_type: str) -> str:
         """Get the attributes topic for a particular entity type."""
-        return f"{self._discovery_prefix}/sensor/{self._unique_id}/{key}/{topic_type}"
+        if key in self._config_topics:
+            return self._config_topics[key]
+        return f"{self._prefix}/{component}/{self._unique_id}/{key}/{topic_type}"
 
     def get_config_payload(self, key: str) -> ConfigPayloadType:
         """Return the config payload for a particular entity type."""
         if key in self._config_payloads:
             return self._config_payloads[key]
 
-        LOGGER.debug("Looking at %s", key)
-        icon, device_class, unit_class, unit = get_data_point_characteristics(key)
+        (
+            component,
+            icon,
+            device_class,
+            unit_class,
+            unit,
+        ) = get_data_point_characteristics(key)
         if unit_class:
             unit = UNIT_MAPPING[unit_class][self._unit_system]
 
         self._config_payloads[key] = {
-            "availability_topic": self._get_topic(key, "availability"),
+            "availability_topic": self._get_topic(key, component, "availability"),
+            "config_topic": self._get_topic(key, component, "config"),
             "device_class": device_class,
             "icon": icon,
             "name": key,
             "qos": 1,
-            "state_topic": self._get_topic(key, "state"),
+            "state_topic": self._get_topic(key, component, "state"),
             "unique_id": f"{self._unique_id}_{key}",
             "unit_of_measurement": unit,
         }
 
         return self._config_payloads[key]
-
-    def get_config_topic(self, key: str) -> str:
-        """Return the config topic for a particular entity type."""
-        return self._get_topic(key, "config")

--- a/ecowitt2mqtt/hass.py
+++ b/ecowitt2mqtt/hass.py
@@ -135,15 +135,12 @@ class HassDiscovery:  # pylint: disable=too-few-public-methods
     ) -> None:
         """Initialize."""
         self._config_payloads: Dict[str, ConfigPayloadType] = {}
-        self._config_topics: Dict[str, str] = {}
         self._prefix = discovery_prefix
         self._unique_id = unique_id
         self._unit_system = unit_system
 
     def _get_topic(self, key: str, component: str, topic_type: str) -> str:
         """Get the attributes topic for a particular entity type."""
-        if key in self._config_topics:
-            return self._config_topics[key]
         return f"{self._prefix}/{component}/{self._unique_id}/{key}/{topic_type}"
 
     def get_config_payload(self, key: str) -> ConfigPayloadType:

--- a/ecowitt2mqtt/mqtt.py
+++ b/ecowitt2mqtt/mqtt.py
@@ -35,10 +35,12 @@ async def _async_publish_to_hass_discovery(
             tasks = []
             for key, value in data.items():
                 config_payload = discovery_manager.get_config_payload(key)
-                config_topic = discovery_manager.get_config_topic(key)
 
                 tasks.append(
-                    client.publish(config_topic, _generate_payload(config_payload))
+                    client.publish(
+                        config_payload["config_topic"],
+                        _generate_payload(config_payload),
+                    )
                 )
                 tasks.append(
                     client.publish(


### PR DESCRIPTION
**Describe what the PR does:**

This PR lays the foundation to publish different types of entities via Home Assistant MQTT Discovery (previously, the library only published `sensor` entities). This paves the way for things like `binary_sensor`-based battery entities.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
