### PR TITLE
Add support for Home Assistant Device Registry

### DIFF
--- a/ecowitt2mqtt/data.py
+++ b/ecowitt2mqtt/data.py
@@ -16,6 +16,7 @@ from ecowitt2mqtt.const import (
     DATA_POINT_WINDSPEEDMPH,
     UNIT_SYSTEM_IMPERIAL,
 )
+from ecowitt2mqtt.device import get_device_from_raw_payload
 from ecowitt2mqtt.helpers.converter import Converter
 from ecowitt2mqtt.helpers.converter.battery import BinaryBatteryConverter
 from ecowitt2mqtt.helpers.converter.meteo import (
@@ -102,6 +103,7 @@ class DataProcessor:  # pylint: disable=too-few-public-methods
 
         self._input_unit_system = input_unit_system
         self._output_unit_system = output_unit_system
+        self.device = get_device_from_raw_payload(payload)
         self.unique_id = payload.get("PASSKEY", DEFAULT_UNIQUE_ID)
 
     def generate_data(self) -> Dict[str, Any]:

--- a/ecowitt2mqtt/device.py
+++ b/ecowitt2mqtt/device.py
@@ -1,0 +1,44 @@
+"""Define an Ecowitt device."""
+from typing import Any, Dict, NamedTuple, Optional
+
+from ecowitt2mqtt.const import LOGGER
+
+DEFAULT_MANUFACTURER = "Unknown"
+DEFAULT_NAME = "Unknown Device"
+DEFAULT_STATION_TYPE = "Unknown Station Type"
+
+DEVICE_DATA = {
+    "GW1000_Pro": ("Ecowitt", "GW1000 Pro"),
+    "WH2650": ("Waldbeck", "Hally Weather Station"),
+}
+
+
+class Device(NamedTuple):
+    """Simple data object to provide device details."""
+
+    manufacturer: str
+    name: str
+    station_type: Optional[str]
+
+
+def get_device_from_raw_payload(payload: Dict[str, Any]) -> Device:
+    """Return a device based upon a model string."""
+    model = payload.get("model")
+    station_type = payload.get("stationtype")
+
+    if not model:
+        return Device(DEFAULT_MANUFACTURER, DEFAULT_NAME, DEFAULT_STATION_TYPE)
+
+    try:
+        manufacturer, name = DEVICE_DATA[model]
+    except KeyError:
+        LOGGER.info(
+            'Unknown device model ("%s"); please report it at '
+            "https://github.com/bachya/ecowitt2mqtt",
+            model,
+        )
+        manufacturer = DEFAULT_MANUFACTURER
+        name = DEFAULT_NAME
+        station_type = DEFAULT_STATION_TYPE
+
+    return Device(manufacturer, name, station_type)

--- a/ecowitt2mqtt/mqtt.py
+++ b/ecowitt2mqtt/mqtt.py
@@ -104,14 +104,14 @@ async def async_publish_payload(request: web.Request) -> None:
                 discovery_manager = discovery_managers[
                     data_processor.unique_id
                 ] = HassDiscovery(
-                    data_processor.unique_id,
+                    data_processor,
                     args.unit_system,
                     discovery_prefix=args.hass_discovery_prefix,
                 )
             else:
                 discovery_manager = discovery_managers[
                     data_processor.unique_id
-                ] = HassDiscovery(data_processor.unique_id, args.unit_system)
+                ] = HassDiscovery(data_processor, args.unit_system)
 
         await _async_publish_to_hass_discovery(client, data, discovery_manager)
     else:


### PR DESCRIPTION
**Describe what the PR does:**

Following up on https://github.com/bachya/ecowitt2mqtt/pull/50 (and the work done by @ErnstEeldert), this PR adds support for including Device Registry support when publishing to Home Assistant MQTT Discovery.

<img width="342" alt="CleanShot 2021-07-31 at 11 07 32@2x" src="https://user-images.githubusercontent.com/47216/127747419-e85a99aa-de05-48ca-8757-861b8e510df7.png">

**Does this fix a specific issue?**

Fixes https://github.com/bachya/ecowitt2mqtt/issues/48
  
**Checklist:**

- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
