### PR TITLE
Fix bug in calculating perceived brightness at low levels

### DIFF
--- a/ecowitt2mqtt/util/meteo.py
+++ b/ecowitt2mqtt/util/meteo.py
@@ -79,7 +79,15 @@ def calculate_illuminance_wm2_to_lux(value: float) -> float:
 def calculate_illuminance_wm2_to_perceived(value: float) -> float:
     """Calculate illuminance (in lux)."""
     lux = calculate_illuminance_wm2_to_lux(value)
-    return round(math.log10(lux) / 5, 2) * 100
+    try:
+        perceived = round(math.log10(lux) / 5, 2) * 100
+    except ValueError:
+        # If we've approached negative infinity, we'll get a math domain error; in that
+        # case, return 0.0:
+        return 0.0
+    if perceived < 0:
+        return 0.0
+    return perceived
 
 
 def calculate_pressure(


### PR DESCRIPTION
**Describe what the PR does:**

Our calculation of perceived brightness could theoretically go below 0, towards negative infinity – both of which would cause errors. This created https://github.com/bachya/ecowitt2mqtt/issues/65. This PR ensures that if we've hit a mathematical calculation that goes below 0 or hits negative infinity, we just return 0.

**Does this fix a specific issue?**

Fixes https://github.com/bachya/ecowitt2mqtt/issues/65
  
**Checklist:**

- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
