### PR TITLE
Add ability to preserve raw (i.e., non-translated) data

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ optional arguments:
                         The Home Assistant discovery prefix to use (default: homeassistant)
   --endpoint ENDPOINT   The relative endpoint/path to serve the web app on (default: /data/report)
   --port PORT           The port to serve the web app on (default: 8080)
+  --raw-data            Return raw data (don't attempt to translate any values)
   --unit-system UNIT_SYSTEM
                         The unit system to use (default: imperial)
 ```
@@ -146,7 +147,7 @@ ExecStart=ecowitt2mqtt --mqtt-broker=192.168.1.101 --mqtt-username=user --mqtt-p
 ExecReload=kill -HUP $MAINPID
 KillMode=process
 Restart=on-failure
-RestartSec=42s
+RestartSec=5s
  
 [Install]
 WantedBy=multi-user.target
@@ -157,6 +158,17 @@ To enable the service:
 ```bash
 $ systemctl enable ecowitt2mqtt
 ```
+
+## Raw Data
+
+In some cases, it may be preferable to prevent `ecowitt2mqtt` from doing any data
+translation (converting values to a new unit system, changing binary values – such as
+might be used by a battery – into "friendly" values, etc.). Passing the `--raw-data` flag
+will accomplish this: data will flow directly from the Ecowitt device to the MQTT broker
+as-is.
+
+Note that the `--raw-data` flag supersedes any that might cause data translation (such as
+`--unit-system`).
 
 ## Home Assistant MQTT Discovery
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -7,15 +7,16 @@ services:
     build: .
     container_name: ecowitt2mqtt
     environment:
-      LOG_LEVEL: INFO
       ENDPOINT: /data/report
       HASS_DISCOVERY: "false"
-      PORT: 8080
+      LOG_LEVEL: INFO
       MQTT_BROKER: vernemq
-      MQTT_PORT: 1883
       MQTT_PASSWORD: password
-      MQTT_USERNAME: ecowitt
+      MQTT_PORT: 1883
       MQTT_TOPIC: Test
+      MQTT_USERNAME: ecowitt
+      PORT: 8080
+      RAW_DATA: "false"
       UNIT_SYSTEM: imperial
     ports:
       - "8080:8080/tcp"

--- a/ecowitt2mqtt/data.py
+++ b/ecowitt2mqtt/data.py
@@ -1,4 +1,5 @@
 """Define helpers to process data from an Ecowitt device."""
+import argparse
 from functools import partial
 import inspect
 from typing import Any, Callable, Dict, Optional, Union
@@ -19,7 +20,6 @@ from ecowitt2mqtt.const import (
     DATA_POINT_TEMPF,
     DATA_POINT_WINDCHILL,
     DATA_POINT_WINDSPEEDMPH,
-    UNIT_SYSTEM_IMPERIAL,
 )
 from ecowitt2mqtt.device import get_device_from_raw_payload
 from ecowitt2mqtt.util.battery import calculate_binary_battery
@@ -85,16 +85,11 @@ def get_data_type(key: str) -> Optional[str]:
 class DataProcessor:  # pylint: disable=too-few-public-methods
     """Define an object that holds processed payload data from the device."""
 
-    def __init__(
-        self,
-        payload: Dict[str, Any],
-        *,
-        input_unit_system: str = UNIT_SYSTEM_IMPERIAL,
-        output_unit_system: str = UNIT_SYSTEM_IMPERIAL
-    ) -> None:
+    def __init__(self, payload: Dict[str, Any], args: argparse.Namespace) -> None:
         """Initialize."""
-        self._input_unit_system = input_unit_system
-        self._output_unit_system = output_unit_system
+        self._args = args
+        self._input_unit_system = args.unit_system
+        self._output_unit_system = args.unit_system
 
         self._payload: Dict[str, Union[float, str]] = {}
         for key, value in payload.items():
@@ -134,7 +129,7 @@ class DataProcessor:  # pylint: disable=too-few-public-methods
 
             calculate = self._get_calculator_func(target_key, value)
 
-            if not calculate:
+            if self._args.raw_data or not calculate:
                 data[target_key] = value
                 continue
 

--- a/ecowitt2mqtt/main.py
+++ b/ecowitt2mqtt/main.py
@@ -96,6 +96,12 @@ def get_arguments() -> argparse.Namespace:
 
     # Misc.
     parser.add_argument(
+        "--raw-data",
+        action="store_const",
+        const=True,
+        help="Return raw data (don't attempt to translate any values)",
+    )
+    parser.add_argument(
         "--unit-system",
         action="store",
         default=UNIT_SYSTEM_IMPERIAL,

--- a/ecowitt2mqtt/mqtt.py
+++ b/ecowitt2mqtt/mqtt.py
@@ -83,7 +83,7 @@ async def async_publish_payload(request: web.Request) -> None:
     payload = dict(await request.post())
     LOGGER.debug("Received data from Ecowitt device: %s", payload)
 
-    data_processor = DataProcessor(payload, output_unit_system=args.unit_system)
+    data_processor = DataProcessor(payload, args)
     data = data_processor.generate_data()
 
     client = Client(

--- a/run.sh
+++ b/run.sh
@@ -28,7 +28,7 @@ if [ -n "${MQTT_PASSWORD}" ]; then
 fi
 
 if [ "${HASS_DISCOVERY}" = "true" ]; then
-    PARAMS+=("--hass-discovery")
+    PARAMS+=(--hass-discovery)
 fi
 
 if [ -n "${HASS_DISCOVERY_PREFIX}" ]; then
@@ -41,6 +41,10 @@ fi
 
 if [ -n "${PORT}" ]; then
     PARAMS+=(--port="${PORT}")
+fi
+
+if [ -n "${RAW_DATA}" ]; then
+    PARAMS+=(--raw-data)
 fi
 
 if [ -n "${UNIT_SYSTEM}" ]; then


### PR DESCRIPTION
**Describe what the PR does:**

https://github.com/bachya/ecowitt2mqtt/issues/18#issuecomment-902104277 gave me the idea that some users of this library might want to do their own data translation (management of unit systems, conversion of binary values, etc.). So, this PR adds a `--raw-data` flag (and corresponding environment variable for Docker) that preserves data from an Ecowitt device to the MQTT broker.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
