### PR TITLE
Add support for specifying both input and output unit systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,47 @@ optional arguments:
   --endpoint ENDPOINT   The relative endpoint/path to serve the web app on (default: /data/report)
   --port PORT           The port to serve the web app on (default: 8080)
   --raw-data            Return raw data (don't attempt to translate any values)
-  --unit-system UNIT_SYSTEM
-                        The unit system to use (default: imperial)
+  --input-unit-system INPUT_UNIT_SYSTEM
+                        The input unit system used by the device (default: imperial)
+  --output-unit-system OUTPUT_UNIT_SYSTEM
+                        The unit system to use in output (default: imperial)
 ```
+## Unit Systems
+
+`ecowitt2mqtt` allows you to specify both the input and output unit systems for a device.
+This is fairly self-explanatory, but take care to use an `--input-unit-system` that is
+consistent with what your device provides (otherwise, your data will be way off).
+
+## Raw Data
+
+In some cases, it may be preferable to prevent `ecowitt2mqtt` from doing any data
+translation (converting values to a new unit system, changing binary values – such as
+might be used by a battery – into "friendly" values, etc.). Passing the `--raw-data` flag
+will accomplish this: data will flow directly from the Ecowitt device to the MQTT broker
+as-is.
+
+Note that the `--raw-data` flag supersedes any that might cause data translation (such as
+`--input-unit-system` or `--output-unit-system`).
+
+## Home Assistant MQTT Discovery
+
+[Home Assistant](https://home-assistant.io) users can quickly add entities from an
+Ecowitt device by using
+[MQTT Discovery](https://www.home-assistant.io/docs/mqtt/discovery/).
+
+Once Home Assistant is configured to accept MQTT Discovery, `ecowitt2mqtt` simply needs
+the `--hass-discovery` flag:
+
+```bash
+$ ecowitt2mqtt \
+    --mqtt-broker=192.168.1.101 \
+    --mqtt-username=user \
+    --mqtt-password=password \
+    --hass-discovery
+```
+
+Note that if both `--hass-discovery` and `--mqtt-topic` are provided, `--hass-discovery` will
+win out.
 
 ## Running in the Background
 
@@ -158,37 +196,6 @@ To enable the service:
 ```bash
 $ systemctl enable ecowitt2mqtt
 ```
-
-## Raw Data
-
-In some cases, it may be preferable to prevent `ecowitt2mqtt` from doing any data
-translation (converting values to a new unit system, changing binary values – such as
-might be used by a battery – into "friendly" values, etc.). Passing the `--raw-data` flag
-will accomplish this: data will flow directly from the Ecowitt device to the MQTT broker
-as-is.
-
-Note that the `--raw-data` flag supersedes any that might cause data translation (such as
-`--unit-system`).
-
-## Home Assistant MQTT Discovery
-
-[Home Assistant](https://home-assistant.io) users can quickly add entities from an
-Ecowitt device by using
-[MQTT Discovery](https://www.home-assistant.io/docs/mqtt/discovery/).
-
-Once Home Assistant is configured to accept MQTT Discovery, `ecowitt2mqtt` simply needs
-the `--hass-discovery` flag:
-
-```bash
-$ ecowitt2mqtt \
-    --mqtt-broker=192.168.1.101 \
-    --mqtt-username=user \
-    --mqtt-password=password \
-    --hass-discovery
-```
-
-Note that if both `--hass-discovery` and `--mqtt-topic` are provided, `--hass-discovery` will
-win out.
 
 ## Docker
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -8,7 +8,7 @@ services:
     container_name: ecowitt2mqtt
     environment:
       ENDPOINT: /data/report
-      HASS_DISCOVERY: "true"
+      HASS_DISCOVERY: "false"
       LOG_LEVEL: INFO
       MQTT_BROKER: vernemq
       MQTT_PASSWORD: password

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -8,16 +8,16 @@ services:
     container_name: ecowitt2mqtt
     environment:
       ENDPOINT: /data/report
-      HASS_DISCOVERY: "false"
+      HASS_DISCOVERY: "true"
       LOG_LEVEL: INFO
       MQTT_BROKER: vernemq
       MQTT_PASSWORD: password
       MQTT_PORT: 1883
       MQTT_TOPIC: Test
       MQTT_USERNAME: ecowitt
+      OUTPUT_UNIT_SYSTEM: imperial
       PORT: 8080
       RAW_DATA: "false"
-      UNIT_SYSTEM: imperial
     ports:
       - "8080:8080/tcp"
     restart: always

--- a/ecowitt2mqtt/data.py
+++ b/ecowitt2mqtt/data.py
@@ -88,8 +88,8 @@ class DataProcessor:  # pylint: disable=too-few-public-methods
     def __init__(self, payload: Dict[str, Any], args: argparse.Namespace) -> None:
         """Initialize."""
         self._args = args
-        self._input_unit_system = args.unit_system
-        self._output_unit_system = args.unit_system
+        self._input_unit_system = args.input_unit_system
+        self._output_unit_system = args.output_unit_system
 
         self._payload: Dict[str, Union[float, str]] = {}
         for key, value in payload.items():

--- a/ecowitt2mqtt/hass.py
+++ b/ecowitt2mqtt/hass.py
@@ -1,4 +1,5 @@
 """Define Home Assistant-related functionality."""
+import argparse
 from typing import Any, Dict, Optional, Tuple
 
 from ecowitt2mqtt.const import (
@@ -29,8 +30,6 @@ from ecowitt2mqtt.device import Device
 
 COMPONENT_BINARY_SENSOR = "binary_sensor"
 COMPONENT_SENSOR = "sensor"
-
-DEFAULT_DISCOVERY_PREFIX = "homeassistant"
 
 DEVICE_CLASS_BATTERY = "battery"
 DEVICE_CLASS_CO = "carbon_monoxide"
@@ -178,24 +177,17 @@ def get_data_point_characteristics(
 class HassDiscovery:  # pylint: disable=too-few-public-methods
     """Define a Home Assistant MQTT Discovery manager."""
 
-    def __init__(
-        self,
-        device: Device,
-        unit_system: str,
-        *,
-        discovery_prefix: str = DEFAULT_DISCOVERY_PREFIX,
-    ) -> None:
+    def __init__(self, device: Device, args: argparse.Namespace,) -> None:
         """Initialize."""
+        self._args = args
         self._config_payloads: Dict[str, Dict[str, Any]] = {}
         self._device = device
-        self._prefix = discovery_prefix
-        self._unit_system = unit_system
 
     def _get_topic(self, key: str, component: str, topic_type: str) -> str:
         """Get the attributes topic for a particular entity type."""
         return (
-            f"{self._prefix}/{component}/{self._device.unique_id}/{key}"
-            f"/{topic_type}"
+            f"{self._args.hass_discovery_prefix}/{component}/{self._device.unique_id}/"
+            f"{key}/{topic_type}"
         )
 
     def get_config_payload(self, key: str) -> Dict[str, Any]:
@@ -211,7 +203,7 @@ class HassDiscovery:  # pylint: disable=too-few-public-methods
             unit,
         ) = get_data_point_characteristics(key)
         if unit_class:
-            unit = UNIT_MAPPING[unit_class][self._unit_system]
+            unit = UNIT_MAPPING[unit_class][self._args.output_unit_system]
 
         self._config_payloads[key] = {
             "availability_topic": self._get_topic(key, component, "availability"),

--- a/ecowitt2mqtt/main.py
+++ b/ecowitt2mqtt/main.py
@@ -9,6 +9,7 @@ from ecowitt2mqtt.mqtt import async_publish_payload
 
 DEFAULT_AIOHTTP_ENDPOINT = "/data/report"
 DEFAULT_AIOHTTP_PORT = 8080
+DEFAULT_HASS_DISCOVERY_PREFIX = "homeassistant"
 DEFAULT_LOG_LEVEL_STRING = "INFO"
 DEFAULT_MQTT_PORT = 1883
 
@@ -72,7 +73,11 @@ def get_arguments() -> argparse.Namespace:
     )
     parser.add_argument(
         "--hass-discovery-prefix",
-        help="The Home Assistant discovery prefix to use (default: homeassistant)",
+        default=DEFAULT_HASS_DISCOVERY_PREFIX,
+        help=(
+            "The Home Assistant discovery prefix to use "
+            f"(default: {DEFAULT_HASS_DISCOVERY_PREFIX})"
+        ),
     )
 
     # Web Server
@@ -102,11 +107,18 @@ def get_arguments() -> argparse.Namespace:
         help="Return raw data (don't attempt to translate any values)",
     )
     parser.add_argument(
-        "--unit-system",
+        "--input-unit-system",
         action="store",
         default=UNIT_SYSTEM_IMPERIAL,
         type=str,
-        help=f"The unit system to use (default: {UNIT_SYSTEM_IMPERIAL})",
+        help=f"The input unit system used by the device (default: {UNIT_SYSTEM_IMPERIAL})",
+    )
+    parser.add_argument(
+        "--output-unit-system",
+        action="store",
+        default=UNIT_SYSTEM_IMPERIAL,
+        type=str,
+        help=f"The unit system to use in output (default: {UNIT_SYSTEM_IMPERIAL})",
     )
 
     return parser.parse_args()

--- a/ecowitt2mqtt/mqtt.py
+++ b/ecowitt2mqtt/mqtt.py
@@ -97,21 +97,11 @@ async def async_publish_payload(request: web.Request) -> None:
     if args.hass_discovery:
         discovery_managers = request.app["hass_discovery_managers"]
 
-        try:
+        if data_processor.device.unique_id in discovery_managers:
             discovery_manager = discovery_managers[data_processor.device.unique_id]
-        except KeyError:
-            if args.hass_discovery_prefix:
-                discovery_manager = discovery_managers[
-                    data_processor.device.unique_id
-                ] = HassDiscovery(
-                    data_processor.device,
-                    args.unit_system,
-                    discovery_prefix=args.hass_discovery_prefix,
-                )
-            else:
-                discovery_manager = discovery_managers[
-                    data_processor.device.unique_id
-                ] = HassDiscovery(data_processor.device, args.unit_system)
+        else:
+            discovery_manager = HassDiscovery(data_processor.device, args)
+            discovery_managers[data_processor.device.unique_id] = discovery_manager
 
         await _async_publish_to_hass_discovery(client, data, discovery_manager)
     else:

--- a/run.sh
+++ b/run.sh
@@ -43,12 +43,16 @@ if [ -n "${PORT}" ]; then
     PARAMS+=(--port="${PORT}")
 fi
 
-if [ -n "${RAW_DATA}" ]; then
+if [ "${RAW_DATA}" = "true" ]; then
     PARAMS+=(--raw-data)
 fi
 
-if [ -n "${UNIT_SYSTEM}" ]; then
-    PARAMS+=(--unit-system="${UNIT_SYSTEM}")
+if [ -n "${INPUT_UNIT_SYSTEM}" ]; then
+    PARAMS+=(--output-unit-system="${INPUT_UNIT_SYSTEM}")
+fi
+
+if [ -n "${OUTPUT_UNIT_SYSTEM}" ]; then
+    PARAMS+=(--output-unit-system="${OUTPUT_UNIT_SYSTEM}")
 fi
 
 python3 /usr/src/ecowitt2mqtt/main.py "${PARAMS[@]}"

--- a/run.sh
+++ b/run.sh
@@ -48,7 +48,7 @@ if [ "${RAW_DATA}" = "true" ]; then
 fi
 
 if [ -n "${INPUT_UNIT_SYSTEM}" ]; then
-    PARAMS+=(--output-unit-system="${INPUT_UNIT_SYSTEM}")
+    PARAMS+=(--input-unit-system="${INPUT_UNIT_SYSTEM}")
 fi
 
 if [ -n "${OUTPUT_UNIT_SYSTEM}" ]; then


### PR DESCRIPTION
**BREAKING CHANGE**

The `--unit-system` flag has been removed and replaced with `--input-unit-system` and `--output-unit-system`. Please update your configurations accordingly.

**Describe what the PR does:**

This PR allows users to specify both the input and output unit systems (anticipating a future where an Ecowitt device might report data in, say, metric to start).

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
