### PR TITLE
Handle non-binary battery values

### DIFF
--- a/ecowitt2mqtt/util/battery.py
+++ b/ecowitt2mqtt/util/battery.py
@@ -1,10 +1,21 @@
 """Define battery utilities."""
+from typing import Union
+
 BATTERY_STATE_OFF = "off"
 BATTERY_STATE_ON = "on"
 
 
-def calculate_binary_battery(value: float) -> str:
-    """Calculate a "binary battery" value (OK/Low)."""
+def calculate_battery(value: Union[float, int]) -> Union[float, str]:
+    """Calculate a battery value.
+
+    1. If the value is a float, we assume it represents voltage and return it as-is.
+    2. If the value is an int, we assume it represents a binary state:
+         * 0: OK
+         * 1: Low
+    """
+    if isinstance(value, float):
+        return value
+
     if value == 0:
         return BATTERY_STATE_OFF
     return BATTERY_STATE_ON


### PR DESCRIPTION
**Describe what the PR does:**

We re-opened #18 because it was determined that Ecowitt devices _can_ report battery values that appear to represent voltage (and not just the binary `OK`/`Low` values that we knew about). This PR attempts to handle this new scenario:

* If a battery reports its value as a float, we interpret that as a voltage and return that value.
* If a battery reports its value as an integer, we interpret that binary state and use our existing logic.

**Does this fix a specific issue?**

Fixes #18
  
**Checklist:**

- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
