### PR TITLE
Fix bug where batteries don't have the correct units for MQTT Discovery

### DIFF
--- a/ecowitt2mqtt/hass.py
+++ b/ecowitt2mqtt/hass.py
@@ -56,7 +56,7 @@ GLOBBED_ENTITIES = {
         None,
         DEVICE_CLASS_BATTERY,
         None,
-        None,
+        "v",
     ),
     DATA_POINT_GLOB_GUST: (
         COMPONENT_SENSOR,


### PR DESCRIPTION
**Describe what the PR does:**

#81 neglected to ensure that non-binary batteries have the correct values when transmitted to Home Assistant (`v`). This PR fixes that issue.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
