### PR TITLE
Round barometric pressure values to 3 decimal places

### DIFF
--- a/ecowitt2mqtt/data.py
+++ b/ecowitt2mqtt/data.py
@@ -90,7 +90,7 @@ def get_typed_value(value: str) -> Union[float, int, str]:
 
     try:
         # Float:
-        return round(float(value), 1)
+        return float(value)
     except ValueError:
         # String:
         return value

--- a/ecowitt2mqtt/util/meteo.py
+++ b/ecowitt2mqtt/util/meteo.py
@@ -100,8 +100,8 @@ def calculate_pressure(
     if input_unit_system == output_unit_system:
         return value
     if output_unit_system == UNIT_SYSTEM_IMPERIAL:
-        return round(value / 33.8639, 1)
-    return round(value * 33.8639, 1)
+        return round(value / 33.8639, 3)
+    return round(value * 33.8639, 3)
 
 
 def calculate_rain_volume(


### PR DESCRIPTION
**Describe what the PR does:**

https://github.com/bachya/ecowitt2mqtt/issues/76 revealed that barometric pressure fluctuates in fairly small amounts (in the hundredth or thousandth decimal place). Because we were rounding these values to 1 decimal point, we were cutting out that nuance and producing really choppy data (noticeable when graphed out). This PR ensures that pressure values are now rounded to 3 decimal points.

**Does this fix a specific issue?**

Fixes https://github.com/bachya/ecowitt2mqtt/issues/76
  
**Checklist:**

- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
