### PR TITLE
Add Ecowitt GW1100 series to the device registry

### DIFF
--- a/ecowitt2mqtt/device.py
+++ b/ecowitt2mqtt/device.py
@@ -10,7 +10,7 @@ DEFAULT_UNIQUE_ID = "default"
 
 DEVICE_DATA = {
     "GW1000": ("Ecowitt", "GW1000"),
-    "GW1100": ("Ecowitt", "GW1000"),
+    "GW1100": ("Ecowitt", "GW1100"),
     "WH2650": ("Fine Offset", "WH2650"),
     "WS2900": ("Ambient Weather", "WS-2902C"),
 }

--- a/ecowitt2mqtt/device.py
+++ b/ecowitt2mqtt/device.py
@@ -9,7 +9,8 @@ DEFAULT_STATION_TYPE = "Unknown Station Type"
 DEFAULT_UNIQUE_ID = "default"
 
 DEVICE_DATA = {
-    "GW1000_Pro": ("Ecowitt", "GW1000 Pro"),
+    "GW1000": ("Ecowitt", "GW1000"),
+    "GW1100": ("Ecowitt", "GW1000"),
     "WH2650": ("Fine Offset", "WH2650"),
     "WS2900": ("Ambient Weather", "WS-2902C"),
 }


### PR DESCRIPTION
**Describe what the PR does:**

Saw this report today:

```json
{
  "PASSKEY": "16E2...E1D",
  "stationtype": "GW1100B_V2.0.3",
  "dateutc": "2021-08-23 23:13:41",
  "tempinf": "76.5",
  "humidityin": "46",
  "baromrelin": "29.244",
  "baromabsin": "29.244",
  "tempf": "91.4",
  "humidity": "48",
  "rainratein": "0.000",
  "eventrainin": "0.000",
  "hourlyrainin": "0.000",
  "dailyrainin": "0.000",
  "weeklyrainin": "0.004",
  "monthlyrainin": "1.402",
  "yearlyrainin": "48.504",
  "totalrainin": "48.504",
  "temp1f": "77.7",
  "humidity1": "51",
  "soilmoisture1": "40",
  "soilmoisture2": "56",
  "wh40batt": "1.6",
  "wh26batt": "0",
  "batt1": "0",
  "soilbatt1": "1.5",
  "soilbatt2": "1.8",
  "freq": "915M",
  "model": "GW1100B"
}
```

...which corresponds to the Ecowitt GW1100 family of devices. This PR ensures that we know about them.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
