### PR TITLE
Introduce EntityDescription dataclass for HASS Discovery

### DIFF
--- a/ecowitt2mqtt/hass.py
+++ b/ecowitt2mqtt/hass.py
@@ -1,6 +1,7 @@
 """Define Home Assistant-related functionality."""
 import argparse
-from typing import Any, Dict, Optional, Tuple
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
 
 from ecowitt2mqtt.const import (
     DATA_POINT_CO2,
@@ -23,18 +24,20 @@ from ecowitt2mqtt.const import (
     DATA_POINT_UV,
     DATA_POINT_WINDCHILL,
     DATA_POINT_WINDDIR,
+    LOGGER,
     UNIT_SYSTEM_IMPERIAL,
     UNIT_SYSTEM_METRIC,
 )
 from ecowitt2mqtt.device import Device
 
-COMPONENT_BINARY_SENSOR = "binary_sensor"
-COMPONENT_SENSOR = "sensor"
+PLATFORM_BINARY_SENSOR = "binary_sensor"
+PLATFORM_SENSOR = "sensor"
 
 DEVICE_CLASS_BATTERY = "battery"
 DEVICE_CLASS_CO = "carbon_monoxide"
 DEVICE_CLASS_HUMIDITY = "humidity"
 DEVICE_CLASS_ILLUMINANCE = "illuminance"
+DEVICE_CLASS_PM25 = "pm25"
 DEVICE_CLASS_PRESSURE = "pressure"
 DEVICE_CLASS_TEMPERATURE = "temperature"
 
@@ -43,109 +46,141 @@ UNIT_CLASS_RAIN = "rain"
 UNIT_CLASS_TEMPERATURE = "temperature"
 UNIT_CLASS_WIND = "wind"
 
-GLOBBED_ENTITIES = {
-    DATA_POINT_GLOB_BAROM: (
-        COMPONENT_SENSOR,
-        None,
-        DEVICE_CLASS_PRESSURE,
-        UNIT_CLASS_PRESSURE,
-        None,
-    ),
-    DATA_POINT_GLOB_BATT: (
-        COMPONENT_BINARY_SENSOR,
-        None,
-        DEVICE_CLASS_BATTERY,
-        None,
-        "v",
-    ),
-    DATA_POINT_GLOB_GUST: (
-        COMPONENT_SENSOR,
-        "mdi:weather-windy",
-        None,
-        UNIT_CLASS_WIND,
-        None,
-    ),
-    DATA_POINT_GLOB_HUMIDITY: (
-        COMPONENT_SENSOR,
-        None,
-        DEVICE_CLASS_HUMIDITY,
-        None,
-        "%",
-    ),
-    DATA_POINT_GLOB_MOISTURE: (COMPONENT_SENSOR, "mdi:water-percent", None, None, "%"),
-    DATA_POINT_GLOB_RAIN: (COMPONENT_SENSOR, "mdi:water", None, UNIT_CLASS_RAIN, None),
-    DATA_POINT_GLOB_TEMP: (
-        COMPONENT_SENSOR,
-        None,
-        DEVICE_CLASS_TEMPERATURE,
-        UNIT_CLASS_TEMPERATURE,
-        None,
-    ),
-    DATA_POINT_GLOB_WIND: (
-        COMPONENT_SENSOR,
-        "mdi:weather-windy",
-        None,
-        UNIT_CLASS_WIND,
-        None,
-    ),
-}
 
-SPECIFIC_ENTITIES = {
-    DATA_POINT_CO2: (COMPONENT_SENSOR, None, DEVICE_CLASS_CO, None, "ppm"),
-    DATA_POINT_DEWPOINT: (
-        COMPONENT_SENSOR,
-        "mdi:thermometer",
-        None,
-        UNIT_CLASS_TEMPERATURE,
-        None,
+@dataclass
+class EntityDescription:
+    """Define a description (set of characteristics) of a Home Assistant entity."""
+
+    key: str
+    platform: str
+
+    device_class: Optional[str] = None
+    icon: Optional[str] = None
+    unit: Optional[str] = None
+    unit_class: Optional[str] = None
+
+
+ENTITY_DESCRIPTIONS = (
+    EntityDescription(
+        key=DATA_POINT_GLOB_BAROM,
+        platform=PLATFORM_SENSOR,
+        device_class=DEVICE_CLASS_PRESSURE,
+        unit_class=UNIT_CLASS_PRESSURE,
     ),
-    DATA_POINT_FEELSLIKE: (
-        COMPONENT_SENSOR,
-        "mdi:thermometer",
-        None,
-        UNIT_CLASS_TEMPERATURE,
-        None,
+    EntityDescription(
+        key=DATA_POINT_GLOB_BATT,
+        platform=PLATFORM_BINARY_SENSOR,
+        device_class=DEVICE_CLASS_BATTERY,
     ),
-    DATA_POINT_HEATINDEX: (
-        COMPONENT_SENSOR,
-        "mdi:thermometer",
-        None,
-        UNIT_CLASS_TEMPERATURE,
-        None,
+    EntityDescription(
+        key=DATA_POINT_GLOB_GUST,
+        platform=PLATFORM_SENSOR,
+        icon="mdi:weather-windy",
+        unit_class=UNIT_CLASS_WIND,
     ),
-    DATA_POINT_PM25: (COMPONENT_SENSOR, "mdi:biohazard", None, None, "µg/m^3"),
-    DATA_POINT_PM25_24H: (COMPONENT_SENSOR, "mdi:biohazard", None, None, "µg/m^3"),
-    DATA_POINT_SOLARRADIATION: (
-        COMPONENT_SENSOR,
-        None,
-        DEVICE_CLASS_ILLUMINANCE,
-        None,
-        "w/m^2",
+    EntityDescription(
+        key=DATA_POINT_GLOB_HUMIDITY,
+        platform=PLATFORM_SENSOR,
+        device_class=DEVICE_CLASS_HUMIDITY,
+        unit="%",
     ),
-    DATA_POINT_SOLARRADIATION_LUX: (
-        COMPONENT_SENSOR,
-        None,
-        DEVICE_CLASS_ILLUMINANCE,
-        None,
-        "lx",
+    EntityDescription(
+        key=DATA_POINT_GLOB_MOISTURE,
+        platform=PLATFORM_SENSOR,
+        icon="mdi:water-percent",
+        unit="%",
     ),
-    DATA_POINT_SOLARRADIATION_PERCEIVED: (
-        COMPONENT_SENSOR,
-        None,
-        DEVICE_CLASS_ILLUMINANCE,
-        None,
-        "%",
+    EntityDescription(
+        key=DATA_POINT_GLOB_RAIN,
+        platform=PLATFORM_SENSOR,
+        icon="mdi:water",
+        unit_class=UNIT_CLASS_RAIN,
     ),
-    DATA_POINT_UV: (COMPONENT_SENSOR, "mdi:weather-sunny", None, None, "UV index"),
-    DATA_POINT_WINDCHILL: (
-        COMPONENT_SENSOR,
-        "mdi:weather-windy",
-        None,
-        UNIT_CLASS_TEMPERATURE,
-        None,
+    EntityDescription(
+        key=DATA_POINT_GLOB_TEMP,
+        platform=PLATFORM_SENSOR,
+        device_class=DEVICE_CLASS_TEMPERATURE,
+        unit_class=UNIT_CLASS_TEMPERATURE,
     ),
-    DATA_POINT_WINDDIR: (COMPONENT_SENSOR, "mdi:weather-windy", None, None, "°"),
-}
+    EntityDescription(
+        key=DATA_POINT_GLOB_WIND,
+        platform=PLATFORM_SENSOR,
+        icon="mdi:weather-windy",
+        unit_class=UNIT_CLASS_WIND,
+    ),
+    EntityDescription(
+        key=DATA_POINT_CO2,
+        platform=PLATFORM_SENSOR,
+        device_class=DEVICE_CLASS_CO,
+        unit="ppm",
+    ),
+    EntityDescription(
+        key=DATA_POINT_DEWPOINT,
+        platform=PLATFORM_SENSOR,
+        icon="mdi:thermometer",
+        unit_class=UNIT_CLASS_TEMPERATURE,
+    ),
+    EntityDescription(
+        key=DATA_POINT_FEELSLIKE,
+        platform=PLATFORM_SENSOR,
+        icon="mdi:thermometer",
+        unit_class=UNIT_CLASS_TEMPERATURE,
+    ),
+    EntityDescription(
+        key=DATA_POINT_HEATINDEX,
+        platform=PLATFORM_SENSOR,
+        icon="mdi:thermometer",
+        unit_class=UNIT_CLASS_TEMPERATURE,
+    ),
+    EntityDescription(
+        key=DATA_POINT_PM25,
+        platform=PLATFORM_SENSOR,
+        device_class=DEVICE_CLASS_PM25,
+        unit="µg/m^3",
+    ),
+    EntityDescription(
+        key=DATA_POINT_PM25_24H,
+        platform=PLATFORM_SENSOR,
+        device_class=DEVICE_CLASS_PM25,
+        unit="µg/m^3",
+    ),
+    EntityDescription(
+        key=DATA_POINT_SOLARRADIATION,
+        platform=PLATFORM_SENSOR,
+        device_class=DEVICE_CLASS_ILLUMINANCE,
+        unit="w/m^2",
+    ),
+    EntityDescription(
+        key=DATA_POINT_SOLARRADIATION_LUX,
+        platform=PLATFORM_SENSOR,
+        device_class=DEVICE_CLASS_ILLUMINANCE,
+        unit="lx",
+    ),
+    EntityDescription(
+        key=DATA_POINT_SOLARRADIATION_PERCEIVED,
+        platform=PLATFORM_SENSOR,
+        device_class=DEVICE_CLASS_ILLUMINANCE,
+        unit="%",
+    ),
+    EntityDescription(
+        key=DATA_POINT_UV,
+        platform=PLATFORM_SENSOR,
+        icon="mdi:weather-sunny",
+        unit="index",
+    ),
+    EntityDescription(
+        key=DATA_POINT_WINDCHILL,
+        platform=PLATFORM_SENSOR,
+        icon="mdi:weather-windy",
+        unit_class=UNIT_CLASS_TEMPERATURE,
+    ),
+    EntityDescription(
+        key=DATA_POINT_WINDDIR,
+        platform=PLATFORM_SENSOR,
+        icon="mdi:weather-windy",
+        unit="°",
+    ),
+)
 
 UNIT_MAPPING = {
     UNIT_CLASS_PRESSURE: {UNIT_SYSTEM_IMPERIAL: "inHg", UNIT_SYSTEM_METRIC: "hPa"},
@@ -155,23 +190,22 @@ UNIT_MAPPING = {
 }
 
 
-def get_data_point_characteristics(
-    key: str,
-) -> Tuple[str, Optional[str], Optional[str], Optional[str], Optional[str]]:
-    """Get a data point's characteristics.
+def get_entity_description(key: str) -> EntityDescription:
+    """Get an entity description for a data key.
 
     1. Return a specific data point if it exists.
     2. Return a globbed data point if it exists.
     3. Return defaults if no specific or globbed data points exist.
     """
-    if key in SPECIFIC_ENTITIES:
-        return SPECIFIC_ENTITIES[key]
+    for description in ENTITY_DESCRIPTIONS:
+        if description.key == key:
+            return description
 
-    matches = [v for k, v in GLOBBED_ENTITIES.items() if k in key]
-    if matches:
-        return matches[0]
+        if description.key in key:
+            return description
 
-    return (COMPONENT_SENSOR, None, None, None, None)
+    LOGGER.info("No entity description found for key: %s", key)
+    return EntityDescription(key=key, platform=PLATFORM_SENSOR)
 
 
 class HassDiscovery:  # pylint: disable=too-few-public-methods
@@ -195,18 +229,16 @@ class HassDiscovery:  # pylint: disable=too-few-public-methods
         if key in self._config_payloads:
             return self._config_payloads[key]
 
-        (
-            component,
-            icon,
-            device_class,
-            unit_class,
-            unit,
-        ) = get_data_point_characteristics(key)
-        if unit_class:
-            unit = UNIT_MAPPING[unit_class][self._args.output_unit_system]
+        description = get_entity_description(key)
+        if description.unit_class:
+            description.unit = UNIT_MAPPING[description.unit_class][
+                self._args.output_unit_system
+            ]
 
         self._config_payloads[key] = {
-            "availability_topic": self._get_topic(key, component, "availability"),
+            "availability_topic": self._get_topic(
+                key, description.platform, "availability"
+            ),
             "device": {
                 "identifiers": [self._device.unique_id],
                 "manufacturer": self._device.manufacturer,
@@ -216,19 +248,19 @@ class HassDiscovery:  # pylint: disable=too-few-public-methods
             },
             "name": key,
             "qos": 1,
-            "state_topic": self._get_topic(key, component, "state"),
+            "state_topic": self._get_topic(key, description.platform, "state"),
             "unique_id": f"{self._device.unique_id}_{key}",
         }
-        if device_class:
-            self._config_payloads[key]["device_class"] = device_class
-        if icon:
-            self._config_payloads[key]["icon"] = icon
-        if unit:
-            self._config_payloads[key]["unit_of_measurement"] = unit
+        if description.device_class:
+            self._config_payloads[key]["device_class"] = description.device_class
+        if description.icon:
+            self._config_payloads[key]["icon"] = description.icon
+        if description.unit:
+            self._config_payloads[key]["native_unit_of_measurement"] = description.unit
 
         return self._config_payloads[key]
 
     def get_config_topic(self, key: str) -> str:
         """Return the config topic for a particular entity type."""
-        component, _, _, _, _ = get_data_point_characteristics(key)
-        return self._get_topic(key, component, "config")
+        description = get_entity_description(key)
+        return self._get_topic(key, description.platform, "config")


### PR DESCRIPTION
**Describe what the PR does:**

Taking a page out of Home Assistant's book, this PR migrates entity information from a series of unwieldy tuples to an `EntityDescription` dataclass – nice cleanup.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
