### PR TITLE
Fix incorrect HASS MQTT Discovery key name

### DIFF
--- a/ecowitt2mqtt/hass.py
+++ b/ecowitt2mqtt/hass.py
@@ -253,7 +253,7 @@ class HassDiscovery:
         if description.icon:
             self._config_payloads[key]["icon"] = description.icon
         if description.unit:
-            self._config_payloads[key]["native_unit_of_measurement"] = description.unit
+            self._config_payloads[key]["unit_of_measurement"] = description.unit
 
         return self._config_payloads[key]
 


### PR DESCRIPTION
**Describe what the PR does:**

This PR fixes an incorrect MQTT Discovery key name.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
