### PR TITLE
Don't treat wind direction as a speed

### DIFF
--- a/ecowitt2mqtt/data.py
+++ b/ecowitt2mqtt/data.py
@@ -20,6 +20,7 @@ from ecowitt2mqtt.const import (
     DATA_POINT_TEMPF,
     DATA_POINT_WINDCHILL,
     DATA_POINT_WINDSPEEDMPH,
+    DATA_POINT_WINDDIR,
 )
 from ecowitt2mqtt.device import get_device_from_raw_payload
 from ecowitt2mqtt.util.battery import calculate_battery
@@ -50,6 +51,8 @@ CALCULATOR_FUNCTION_MAP: Dict[str, Callable] = {
     DATA_POINT_SOLARRADIATION_LUX: calculate_illuminance_wm2_to_lux,
     DATA_POINT_SOLARRADIATION_PERCEIVED: calculate_illuminance_wm2_to_perceived,
     DATA_POINT_WINDCHILL: calculate_wind_chill,
+    # Prevent WINDDIR being converted by GLOB_WIND:
+    DATA_POINT_WINDDIR: lambda x: x,
 }
 
 DEW_POINT_KEYS = (DATA_POINT_TEMPF, DATA_POINT_HUMIDITY)

--- a/ecowitt2mqtt/data.py
+++ b/ecowitt2mqtt/data.py
@@ -19,8 +19,8 @@ from ecowitt2mqtt.const import (
     DATA_POINT_SOLARRADIATION_PERCEIVED,
     DATA_POINT_TEMPF,
     DATA_POINT_WINDCHILL,
-    DATA_POINT_WINDSPEEDMPH,
     DATA_POINT_WINDDIR,
+    DATA_POINT_WINDSPEEDMPH,
 )
 from ecowitt2mqtt.device import get_device_from_raw_payload
 from ecowitt2mqtt.util.battery import calculate_battery


### PR DESCRIPTION
**Describe what the PR does:**

If `input_unit_system` is different from `output_unit_system` then wind
direction is treated as a speed and "converted", resulting in incorrect
values. Add a no-op calculator function for `WINDDIR` to stop it being
matched by `GLOB_WIND`.

Fixes #91 

**Checklist:**

- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.