### PR TITLE
Add Fine Offset HP2550 to the device database

### DIFF
--- a/ecowitt2mqtt/device.py
+++ b/ecowitt2mqtt/device.py
@@ -11,6 +11,7 @@ DEFAULT_UNIQUE_ID = "default"
 DEVICE_DATA = {
     "GW1000": ("Ecowitt", "GW1000"),
     "GW1100": ("Ecowitt", "GW1100"),
+    "PT-HP2550": ("Fine Offset", "HP2550"),
     "WH2650": ("Fine Offset", "WH2650"),
     "WS2900": ("Ambient Weather", "WS-2902C"),
 }


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds the [Fine Offset HP2550](http://www.foshk.com/Wifi_Weather_Station/HP2550.html) to the device database.

**Does this fix a specific issue?**

Related to https://github.com/bachya/ecowitt2mqtt/issues/94
  
**Checklist:**

- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
