### PR TITLE
Add Python 3.9 and 3.10 as supported versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,18 +52,20 @@ classifiers = [
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 
 [tool.poetry.dependencies]
-aiohttp = "^3.7.4"
+aiohttp = "^3.7.4post0"
 asyncio-mqtt = "^0.7.0"
 meteocalc = "^1.1.0"
 python = "^3.6.1"
 
 [tool.poetry.dev-dependencies]
-pre-commit = "^2.0.1"
+pre-commit = "^2.15.0"
 
 [tool.poetry.scripts]
 ecowitt2mqtt = "ecowitt2mqtt.main:main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-aiohttp>=3.7.4
+aiohttp>=3.7.4post0
 asyncio-mqtt==0.7.0
 meteocalc==1.1.0


### PR DESCRIPTION
**Describe what the PR does:**

This PR marks the library as compatible with Python 3.9 and 3.10.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
