### PR TITLE
Bump `asyncio-mqtt` to 0.12.1

### DIFF
--- a/ecowitt2mqtt/mqtt.py
+++ b/ecowitt2mqtt/mqtt.py
@@ -10,6 +10,8 @@ from ecowitt2mqtt.const import LOGGER
 from ecowitt2mqtt.data import DataProcessor
 from ecowitt2mqtt.hass import HassDiscovery
 
+DEFAULT_MAX_MQTT_CALLS = 10
+
 
 def _generate_payload(data: Union[Dict[str, Any], float, str]) -> bytes:
     """Generate a binary MQTT payload from input data."""
@@ -92,6 +94,7 @@ async def async_publish_payload(request: web.Request) -> None:
         username=args.mqtt_username,
         password=args.mqtt_password,
         logger=LOGGER,
+        max_concurrent_outgoing_calls=DEFAULT_MAX_MQTT_CALLS,
     )
 
     if args.hass_discovery:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 aiohttp = "^3.7.4post0"
-asyncio-mqtt = "^0.11.0"
+asyncio-mqtt = ">=0.12.1"
 meteocalc = "^1.1.0"
 python = "^3.6.1"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 aiohttp==3.8.1
-asyncio-mqtt==0.11.0
+asyncio-mqtt==0.12.1
 meteocalc==1.1.0


### PR DESCRIPTION
**Describe what the PR does:**

This PR bumps `asyncio-mqtt` to 0.12.1; in so doing, it adds support for backpressure-ing the MQTT broker when the Ecowitt device transmits a ton of MQTT messages.

**Does this fix a specific issue?**

Fixes https://github.com/bachya/ecowitt2mqtt/issues/103
  
**Checklist:**

- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
