### PR TITLE
add support for GW2001 weather station

### DIFF
--- a/ecowitt2mqtt/device.py
+++ b/ecowitt2mqtt/device.py
@@ -11,6 +11,7 @@ DEFAULT_UNIQUE_ID = "default"
 DEVICE_DATA = {
     "GW1000": ("Ecowitt", "GW1000"),
     "GW1100": ("Ecowitt", "GW1100"),
+    "GW2000A": ("Ecowitt", "GW2000A"),
     "PT-HP2550": ("Fine Offset", "HP2550"),
     "WH2650": ("Fine Offset", "WH2650"),
     "WS2900": ("Ambient Weather", "WS-2902C"),


### PR DESCRIPTION
**Describe what the PR does:**

Add support for the ecowitt [GW2001](https://www.ecowitt.com/shop/goodsDetail/245)

With the addition in this PR I have managed having it now appear into my homeassistant:

![Screenshot_20220410_001351](https://user-images.githubusercontent.com/1785235/162593192-e3b0ae25-9adb-4232-b604-ea59e714afa2.png)



**Does this fix a specific issue?**

Fixes https://github.com/bachya/ecowitt2mqtt/issues/116
  
**Checklist:**

- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
