### PR TITLE
Fix bug where lightning strike distance is a string

### DIFF
--- a/ecowitt2mqtt/util/distance.py
+++ b/ecowitt2mqtt/util/distance.py
@@ -1,16 +1,20 @@
 """Define distance utilities."""
+from typing import Any
+
 from ecowitt2mqtt.const import UNIT_SYSTEM_IMPERIAL
 
 
 def calculate_distance(
-    value: float,
+    value: Any,
     *,
     input_unit_system: str = UNIT_SYSTEM_IMPERIAL,
     output_unit_system: str = UNIT_SYSTEM_IMPERIAL
 ) -> float:
     """Calculate distance in the appropriate unit system."""
+    float_value = float(value)
+
     if input_unit_system == output_unit_system:
-        return value
+        return float_value
     if output_unit_system == UNIT_SYSTEM_IMPERIAL:
-        return round(value / 1.609, 1)
-    return round(value * 1.609, 1)
+        return round(float_value / 1.609, 1)
+    return round(float_value * 1.609, 1)


### PR DESCRIPTION
**Describe what the PR does:**

Lightning strike distance can sometimes enter `ecowitt2mqtt` as a string, which will break data interpretation. This PR fixes that issue by ensuring that values are `float`-ed first.

**Does this fix a specific issue?**

Fixes https://github.com/bachya/ecowitt2mqtt/issues/118
  
**Checklist:**

- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
