### PR TITLE
Handle case where distance conversion function is handled bad input

### DIFF
--- a/ecowitt2mqtt/util/distance.py
+++ b/ecowitt2mqtt/util/distance.py
@@ -1,7 +1,7 @@
 """Define distance utilities."""
-from typing import Any
+from typing import Any, Optional
 
-from ecowitt2mqtt.const import UNIT_SYSTEM_IMPERIAL
+from ecowitt2mqtt.const import LOGGER, UNIT_SYSTEM_IMPERIAL
 
 
 def calculate_distance(
@@ -9,9 +9,13 @@ def calculate_distance(
     *,
     input_unit_system: str = UNIT_SYSTEM_IMPERIAL,
     output_unit_system: str = UNIT_SYSTEM_IMPERIAL
-) -> float:
+) -> Optional[float]:
     """Calculate distance in the appropriate unit system."""
-    float_value = float(value)
+    try:
+        float_value = float(value)
+    except ValueError:
+        LOGGER.debug("Could not convert distance value to float: %s", value)
+        return None
 
     if input_unit_system == output_unit_system:
         return float_value


### PR DESCRIPTION
**Describe what the PR does:**

https://github.com/bachya/ecowitt2mqtt/issues/121 revealed that at least in the case of lightning sensors, the "last strike distance" value can arrive as an empty string, which breaks the distance calculation function. This PR fixes that bug by returning `None` anytime a non-number input is received.

**Does this fix a specific issue?**

Fixes https://github.com/bachya/ecowitt2mqtt/issues/121
  
**Checklist:**

- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
