### PR TITLE
Add ability to configure prefix for Home Assistant entity IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ optional arguments:
   --hass-discovery      Publish data in the Home Assistant MQTT Discovery format
   --hass-discovery-prefix HASS_DISCOVERY_PREFIX
                         The Home Assistant discovery prefix to use (default: homeassistant)
+  --hass-entity-id-prefix HASS_ENTITY_ID_PREFIX
+                        The prefix to use for Home Assistant entity IDs
   --endpoint ENDPOINT   The relative endpoint/path to serve the web app on (default: /data/report)
   --port PORT           The port to serve the web app on (default: 8080)
   --raw-data            Return raw data (don't attempt to translate any values)
@@ -213,6 +215,7 @@ listed above:
 * `HASS_DISCOVERY`: whether to use Home Assistant MQTT Discovery (default: `false`)
 * `HASS_DISCOVERY_PREFIX`: the topic prefix to use for Home Assistant MQTT Discovery
   (default: `homeassistant`)
+* `HASS_ENTITY_ID_PREFIX`: the prefix to use for Home Assistant entity IDs
 * `ENDPOINT:` the relative endpoint/path to serve the web app on (default: `/data/report`)
 * `PORT:` the port to serve the web app on (default: `8080`)
 * `INPUT_UNIT_SYSTEM`: the input unit system to use (`imperial` or `metric`) (default: `imperial`)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -7,6 +7,8 @@ services:
     build: .
     container_name: ecowitt2mqtt
     environment:
+      HASS_DISCOVERY: "true"
+      HASS_ENTITY_ID_PREFIX: aaron
       LOG_LEVEL: INFO
       MQTT_BROKER: vernemq
       MQTT_PASSWORD: password

--- a/ecowitt2mqtt/hass.py
+++ b/ecowitt2mqtt/hass.py
@@ -307,6 +307,11 @@ class HassDiscovery:
                 self._args.output_unit_system
             ]
 
+        if self._args.hass_entity_id_prefix:
+            name = f"{self._args.hass_entity_id_prefix}_{key}"
+        else:
+            name = key
+
         self._config_payloads[key] = {
             "availability_topic": self._get_topic(
                 key, description.platform, "availability"
@@ -318,7 +323,7 @@ class HassDiscovery:
                 "name": self._device.name,
                 "sw_version": self._device.station_type,
             },
-            "name": key,
+            "name": name,
             "qos": 1,
             "state_topic": self._get_topic(key, description.platform, "state"),
             "unique_id": f"{self._device.unique_id}_{key}",

--- a/ecowitt2mqtt/main.py
+++ b/ecowitt2mqtt/main.py
@@ -74,6 +74,14 @@ def get_arguments() -> argparse.Namespace:
     parser.add_argument(
         "--hass-discovery-prefix",
         default=DEFAULT_HASS_DISCOVERY_PREFIX,
+        action="store",
+        type=str,
+        help="The prefix to use for Home Assistant entity IDs",
+    )
+    parser.add_argument(
+        "--hass-entity-id-prefix",
+        action="store",
+        type=str,
         help=(
             "The Home Assistant discovery prefix to use "
             f"(default: {DEFAULT_HASS_DISCOVERY_PREFIX})"

--- a/run.sh
+++ b/run.sh
@@ -35,6 +35,10 @@ if [ -n "${HASS_DISCOVERY_PREFIX}" ]; then
     PARAMS+=(--hass-discovery-prefix="${HASS_DISCOVERY_PREFIX}")
 fi
 
+if [ -n "${HASS_ENTITY_ID_PREFIX}" ]; then
+    PARAMS+=(--hass-entity-id-prefix="${HASS_ENTITY_ID_PREFIX}")
+fi
+
 if [ -n "${ENDPOINT}" ]; then
     PARAMS+=(--endpoint="${ENDPOINT}")
 fi


### PR DESCRIPTION
**Describe what the PR does:**

This PR creates the option of an environment variable that, when set, is prefixed to Home Assistant entity IDs.

**Does this fix a specific issue?**

Fixes https://github.com/bachya/ecowitt2mqtt/issues/127
  
**Checklist:**

- [x] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
