### PR TITLE
Fixed descriptions of the prefix parameters

### DIFF
--- a/ecowitt2mqtt/main.py
+++ b/ecowitt2mqtt/main.py
@@ -76,16 +76,16 @@ def get_arguments() -> argparse.Namespace:
         default=DEFAULT_HASS_DISCOVERY_PREFIX,
         action="store",
         type=str,
-        help="The prefix to use for Home Assistant entity IDs",
+        help=(
+            "The Home Assistant discovery prefix to use "
+            f"(default: {DEFAULT_HASS_DISCOVERY_PREFIX})"
+        ),        
     )
     parser.add_argument(
         "--hass-entity-id-prefix",
         action="store",
         type=str,
-        help=(
-            "The Home Assistant discovery prefix to use "
-            f"(default: {DEFAULT_HASS_DISCOVERY_PREFIX})"
-        ),
+        help="The prefix to use for Home Assistant entity IDs",
     )
 
     # Web Server

--- a/ecowitt2mqtt/main.py
+++ b/ecowitt2mqtt/main.py
@@ -79,7 +79,7 @@ def get_arguments() -> argparse.Namespace:
         help=(
             "The Home Assistant discovery prefix to use "
             f"(default: {DEFAULT_HASS_DISCOVERY_PREFIX})"
-        ),        
+        ),
     )
     parser.add_argument(
         "--hass-entity-id-prefix",


### PR DESCRIPTION
Descriptions of "--hass-discovery-prefix" and "--hass-entity-id-prefix" were inverted.