### PR TITLE
Fix poetry.lock issue in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,12 +18,13 @@ RUN apk add --no-cache \
       build-base==0.5-r2 \
       libffi-dev==3.4.2-r1 \
     && pip install --no-cache-dir poetry==$POETRY_VERSION \
-    && python -m venv /venv
+    && python -m venv /venv \
 
-COPY pyproject.toml poetry.lock ./
+COPY pyproject.toml ./
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN poetry export --without-hashes -f requirements.txt \
-    | /venv/bin/pip install -r /dev/stdin
+RUN poetry lock \
+    && poetry export --without-hashes -f requirements.txt \
+       | /venv/bin/pip install -r /dev/stdin
 
 COPY . .
 RUN poetry build && /venv/bin/pip install dist/*.whl

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apk add --no-cache \
       build-base==0.5-r2 \
       libffi-dev==3.4.2-r1 \
     && pip install --no-cache-dir poetry==$POETRY_VERSION \
-    && python -m venv /venv \
+    && python -m venv /venv
 
 COPY pyproject.toml ./
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]


### PR DESCRIPTION
**Describe what the PR does:**

We don't commit `poetry.lock` to the repo, but when building the Docker image, we were assuming it was already there. This PR updates the Dockerfile to generate it upon build.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
