### PR TITLE
Remove unused parameter from utility

### DIFF
--- a/ecowitt2mqtt/server.py
+++ b/ecowitt2mqtt/server.py
@@ -40,7 +40,7 @@ class Server:
         payload = await request.json()
         LOGGER.debug("Received data from the Ecowitt device: %s", payload)
         for callback in self._device_payload_callbacks:
-            execute_callback(self.ecowitt, callback, payload)
+            execute_callback(callback, payload)
 
     def add_device_payload_callback(
         self, callback: Callable[[dict[str, Any]], Coroutine | None]

--- a/ecowitt2mqtt/util/__init__.py
+++ b/ecowitt2mqtt/util/__init__.py
@@ -2,17 +2,12 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Any, Callable, Iterable
+from typing import Any, Callable, Iterable
 
 from thefuzz import fuzz
 
-if TYPE_CHECKING:
-    from ecowitt2mqtt.core import Ecowitt
 
-
-def execute_callback(
-    ecowitt: Ecowitt, callback: Callable[..., Any], *args: Any
-) -> None:
+def execute_callback(callback: Callable[..., Any], *args: Any) -> None:
     """Schedule a callback to be called."""
     if asyncio.iscoroutinefunction(callback):
         asyncio.create_task(callback(*args))


### PR DESCRIPTION
**Describe what the PR does:**

This PR removes an unused parameter from the `execute_callback` utility.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
