### PR TITLE
Ensure HASS Discovery futures are created after MQTT connection is established

### DIFF
--- a/ecowitt2mqtt/helpers/publisher/hass.py
+++ b/ecowitt2mqtt/helpers/publisher/hass.py
@@ -327,9 +327,8 @@ class HomeAssistantDiscoveryPublisher(MqttPublisher):
             try:
                 await asyncio.gather(*futures)
             except MqttError as err:
-                for task in futures:
-                    LOGGER.debug("Canceling publish task: %s", task)
-                    task.cancel()
+                for future in futures:
+                    future.cancel()
                 raise PublishError(
                     f"Error while publishing to Home Assisstant MQTT Discovery: {err}"
                 ) from err

--- a/ecowitt2mqtt/helpers/publisher/hass.py
+++ b/ecowitt2mqtt/helpers/publisher/hass.py
@@ -319,14 +319,14 @@ class HomeAssistantDiscoveryPublisher(MqttPublisher):
                 (discovery_payload.payload["state_topic"], data_point.value),
             ):
                 publish_tasks.append(
-                    asyncio.ensure_future(
-                        self.client.publish(topic, generate_mqtt_payload(payload))
-                    )
+                    self.client.publish(topic, generate_mqtt_payload(payload))
                 )
 
         try:
             async with self.client:
-                await asyncio.gather(*publish_tasks)
+                await asyncio.gather(
+                    *[asyncio.ensure_future(task) for task in publish_tasks]
+                )
         except MqttError as err:
             for task in publish_tasks:
                 task.cancel()

--- a/tests/publisher/test_hass_discovery.py
+++ b/tests/publisher/test_hass_discovery.py
@@ -887,7 +887,7 @@ async def test_publish_numeric_battery_strategy(
         }
     ],
 )
-async def test_publish_error_mqtt(device_data_gw1000pro, ecowitt):
+async def test_publish_error_mqtt(device_data_gw1000pro, ecowitt, setup_asyncio_mqtt):
     """Test handling an asyncio-mqtt error when publishing."""
     publisher = get_publisher(ecowitt)
     with patch.object(publisher.client, "publish", side_effect=MqttError):


### PR DESCRIPTION
**Describe what the PR does:**

The current method of ensuring `asyncio` futures when publishing to Home Assistant MQTT Discovery could lead to the connection being closed before every publish was complete. This PR fixes that bug.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
