### PR TITLE
Fix bug with parsing form data from an Ecowitt gateway

### DIFF
--- a/ecowitt2mqtt/server.py
+++ b/ecowitt2mqtt/server.py
@@ -37,7 +37,7 @@ class Server:
 
     async def _post_data(self, request: Request) -> Response:
         """Define an endpoint for the Ecowitt device to post data to."""
-        payload = await request.json()
+        payload = await request.form()
         LOGGER.debug("Received data from the Ecowitt device: %s", payload)
         for callback in self._device_payload_callbacks:
             execute_callback(callback, payload)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ asyncio-mqtt = ">=0.12.1"
 fastapi = "^0.78.0"
 meteocalc = "^1.1.0"
 python = "^3.8.0"
+python-multipart = "^0.0.5"
 thefuzz = {extras = ["speedup"], version = "^0.19.0"}
 typer = {extras = ["all"], version = "^0.4.1"}
 uvicorn = "^0.17.6"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, Mock, patch
 
 from aiohttp import ClientSession
+from fastapi.datastructures import FormData
 import pytest
 
 from ecowitt2mqtt.core import Ecowitt
@@ -27,13 +28,13 @@ async def test_payload_callback(device_data_gw1000bpro, ecowitt, start_server):
         resp = await session.request(
             "post",
             f"http://127.0.0.1:{TEST_PORT}{TEST_ENDPOINT}",
-            json=device_data_gw1000bpro,
+            data=device_data_gw1000bpro,
         )
         assert resp.status == 204
 
-    mock_callback_1.assert_called_once_with(device_data_gw1000bpro)
+    mock_callback_1.assert_called_once_with(FormData(device_data_gw1000bpro))
     mock_callback_2.assert_not_called()
-    mock_callback_3.assert_awaited_once_with(device_data_gw1000bpro)
+    mock_callback_3.assert_awaited_once_with(FormData(device_data_gw1000bpro))
 
 
 def test_server_start(config):


### PR DESCRIPTION
**Describe what the PR does:**

We mistakenly assumed that Ecowitt gateways transmit JSON, when really, they transmit form data. This would cause the server parser to break. This PR fixes the issue.

**Does this fix a specific issue?**

Fixes https://github.com/bachya/ecowitt2mqtt/issues/<ISSUE ID>

**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
