### PR TITLE
Batt percentag

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,8 +274,10 @@ batteries should be treated by default:
 
 * `boolean`: `0` represents `OFF` (i.e., the battery is in normal condition) and `1`
    represents `ON` (i.e., the battery is low).
-* `numeric`: the raw numeric value is interpreted as the amount of voltage remaining in
+* `numeric`: the raw numeric value is interpreted as the number of volts remaining in
    the battery.
+* `percentage`: the raw numeric value is interpreted as the percentage of voltage
+   remaining the battery.
 
 ### Battery Overrides
 

--- a/ecowitt2mqtt/helpers/calculator/battery.py
+++ b/ecowitt2mqtt/helpers/calculator/battery.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ecowitt2mqtt.backports.enum import StrEnum
-from ecowitt2mqtt.const import DATA_POINT_GLOB_VOLT, ELECTRIC_POTENTIAL_VOLT
+from ecowitt2mqtt.const import DATA_POINT_GLOB_VOLT, ELECTRIC_POTENTIAL_VOLT, PERCENTAGE
 from ecowitt2mqtt.helpers.calculator import CalculatedDataPoint
 
 if TYPE_CHECKING:
@@ -16,6 +16,7 @@ class BatteryStrategy(StrEnum):
 
     BOOLEAN = "boolean"
     NUMERIC = "numeric"
+    PERCENTAGE = "percentage"
 
 
 class BooleanBatteryState(StrEnum):
@@ -29,14 +30,17 @@ def calculate_battery(
     ecowitt: Ecowitt, payload_key: str, data_point_key: str, *, value: float
 ) -> CalculatedDataPoint:
     """Calculate a battery value."""
-    if not (config := ecowitt.config.battery_overrides.get(payload_key)):
-        config = ecowitt.config.default_battery_strategy
+    if not (strategy := ecowitt.config.battery_overrides.get(payload_key)):
+        strategy = ecowitt.config.default_battery_strategy
 
-    if config == BatteryStrategy.NUMERIC or data_point_key == DATA_POINT_GLOB_VOLT:
+    if strategy == BatteryStrategy.NUMERIC or data_point_key == DATA_POINT_GLOB_VOLT:
         return CalculatedDataPoint(
             data_point_key=data_point_key, value=value, unit=ELECTRIC_POTENTIAL_VOLT
         )
-
+    if strategy == BatteryStrategy.PERCENTAGE:
+        return CalculatedDataPoint(
+            data_point_key=data_point_key, value=value, unit=PERCENTAGE
+        )
     if value == 0.0:
         return CalculatedDataPoint(
             data_point_key=data_point_key, value=BooleanBatteryState.OFF

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -48,11 +48,16 @@ from tests.common import TEST_ENDPOINT, TEST_PORT, TEST_RAW_JSON, TEST_RAW_YAML
 
 def test_battery_overrides_cli_options(config):
     """Test battery configs provided by CLI options."""
-    config[CONF_BATTERY_OVERRIDES] = ("wh65batt0=boolean", "wh65batt1=numeric")
+    config[CONF_BATTERY_OVERRIDES] = (
+        "testbatt0=boolean",
+        "testbatt1=numeric",
+        "testbatt2=percentage",
+    )
     config = Config(config)
     assert config.battery_overrides == {
-        "wh65batt0": BatteryStrategy.BOOLEAN,
-        "wh65batt1": BatteryStrategy.NUMERIC,
+        "testbatt0": BatteryStrategy.BOOLEAN,
+        "testbatt1": BatteryStrategy.NUMERIC,
+        "testbatt2": BatteryStrategy.PERCENTAGE,
     }
     assert config.default_battery_strategy == BatteryStrategy.BOOLEAN
 
@@ -64,8 +69,9 @@ def test_battery_overrides_cli_options(config):
             {
                 **json.loads(TEST_RAW_JSON),
                 CONF_BATTERY_OVERRIDES: {
-                    "wh65batt0": "boolean",
-                    "wh65batt1": "numeric",
+                    "testbatt0": "boolean",
+                    "testbatt1": "numeric",
+                    "testbatt2": "percentage",
                 },
             }
         )
@@ -75,25 +81,29 @@ def test_battery_overrides_config_file(config_filepath):
     """Test battery configs provided by a config file."""
     config = Config({CONF_CONFIG: config_filepath})
     assert config.battery_overrides == {
-        "wh65batt0": BatteryStrategy.BOOLEAN,
-        "wh65batt1": BatteryStrategy.NUMERIC,
+        "testbatt0": BatteryStrategy.BOOLEAN,
+        "testbatt1": BatteryStrategy.NUMERIC,
+        "testbatt2": BatteryStrategy.PERCENTAGE,
     }
 
 
 def test_battery_overrides_env_vars(config):
     """Test battery configs provided by environment variables."""
-    os.environ[ENV_BATTERY_OVERRIDE] = "wh65batt0=boolean;wh65batt1=numeric"
+    os.environ[
+        ENV_BATTERY_OVERRIDE
+    ] = "testbatt0=boolean;testbatt1=numeric;testbatt2=percentage"
     config = Config(config)
     assert config.battery_overrides == {
-        "wh65batt0": BatteryStrategy.BOOLEAN,
-        "wh65batt1": BatteryStrategy.NUMERIC,
+        "testbatt0": BatteryStrategy.BOOLEAN,
+        "testbatt1": BatteryStrategy.NUMERIC,
+        "testbatt2": BatteryStrategy.PERCENTAGE,
     }
     os.environ.pop(ENV_BATTERY_OVERRIDE)
 
 
 def test_battery_overrides_error(config):
     """Test handling invalid battery configs."""
-    config[CONF_BATTERY_OVERRIDES] = ("wh65batt0;boolean", "wh65batt1=numeric")
+    config[CONF_BATTERY_OVERRIDES] = ("testbatt0;boolean", "testbatt1=numeric")
     with pytest.raises(ConfigError):
         _ = Config(config)
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -65,7 +65,11 @@ from tests.common import (
     "config",
     [
         {
-            CONF_BATTERY_OVERRIDES: ("wh40batt=numeric", "soilbatt1=numeric"),
+            CONF_BATTERY_OVERRIDES: (
+                "wh40batt=numeric",
+                "soilbatt1=numeric",
+                "wh26batt=percentage",
+            ),
             CONF_DEFAULT_BATTERY_STRATEGY: BatteryStrategy.BOOLEAN,
             CONF_ENDPOINT: TEST_ENDPOINT,
             CONF_HASS_DISCOVERY: False,
@@ -107,7 +111,7 @@ def test_battery_config(device_data_gw1100b, ecowitt):
         "soilmoisture1": CalculatedDataPoint("moisture", 40, unit=PERCENTAGE),
         "soilmoisture2": CalculatedDataPoint("moisture", 56, unit=PERCENTAGE),
         "wh40batt": CalculatedDataPoint("batt", 1.6, unit=ELECTRIC_POTENTIAL_VOLT),
-        "wh26batt": CalculatedDataPoint("batt", BooleanBatteryState.OFF),
+        "wh26batt": CalculatedDataPoint("batt", 0.0, unit=PERCENTAGE),
         "batt1": CalculatedDataPoint("batt", BooleanBatteryState.OFF),
         "soilbatt1": CalculatedDataPoint("batt", 1.5, unit=ELECTRIC_POTENTIAL_VOLT),
         "soilbatt2": CalculatedDataPoint("batt", BooleanBatteryState.ON),


### PR DESCRIPTION
**Describe what the PR does:**

This PR introduces a third battery configuration strategy: percentage (whereby a battery's numeric value is interpreted as the percentage of voltage remaining).

Partially fixes https://github.com/bachya/ecowitt2mqtt/issues/155

Related 

**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [x] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
