### PR TITLE
Fix bug with improperly calculated percentage battery values

### DIFF
--- a/ecowitt2mqtt/helpers/calculator/battery.py
+++ b/ecowitt2mqtt/helpers/calculator/battery.py
@@ -156,8 +156,15 @@ def calculate_battery(
             data_point_key=data_point_key, value=value, unit=ELECTRIC_POTENTIAL_VOLT
         )
     if strategy == BatteryStrategy.PERCENTAGE:
+        # Percentage batteries occur in "steps":
+        #   * 1 = 20%
+        #   * 2 = 40%
+        #   * 3 = 60%
+        #   * 4 = 80%
+        #   * 5 = 100%
+        #   * 6 = 120% (plugged into mains voltage)
         return CalculatedDataPoint(
-            data_point_key=data_point_key, value=value, unit=PERCENTAGE
+            data_point_key=data_point_key, value=value * 20, unit=PERCENTAGE
         )
     if value == 0.0:
         return CalculatedDataPoint(

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -327,7 +327,7 @@ def test_missing_distance(device_data_gw2000a_1, ecowitt, request):
         "lightning_num": CalculatedDataPoint("lightning_num", 1, unit=STRIKES),
         "lightning": CalculatedDataPoint("lightning", 27, unit=DISTANCE_MILES),
         "wh57batt": CalculatedDataPoint(
-            data_point_key="batt", value=5.0, unit=PERCENTAGE
+            data_point_key="batt", value=100, unit=PERCENTAGE
         ),
         "wh90batt": CalculatedDataPoint(
             data_point_key="batt", value=3.16, unit=ELECTRIC_POTENTIAL_VOLT
@@ -531,7 +531,7 @@ def test_missing_distance(device_data_gw2000a_1, ecowitt, request):
                     "lightning", 27.0, unit=DISTANCE_MILES
                 ),
                 "wh57batt": CalculatedDataPoint(
-                    data_point_key="batt", value=5.0, unit=PERCENTAGE
+                    data_point_key="batt", value=100, unit=PERCENTAGE
                 ),
                 "wh90batt": CalculatedDataPoint(
                     data_point_key="batt", value=3.16, unit=ELECTRIC_POTENTIAL_VOLT
@@ -675,13 +675,13 @@ def test_missing_distance(device_data_gw2000a_1, ecowitt, request):
                     data_point_key="batt", value=1.3, unit=ELECTRIC_POTENTIAL_VOLT
                 ),
                 "pm25batt1": CalculatedDataPoint(
-                    data_point_key="batt", value=3.0, unit=PERCENTAGE
+                    data_point_key="batt", value=60, unit=PERCENTAGE
                 ),
                 "wh57batt": CalculatedDataPoint(
-                    data_point_key="batt", value=3.0, unit=PERCENTAGE
+                    data_point_key="batt", value=60, unit=PERCENTAGE
                 ),
                 "co2_batt": CalculatedDataPoint(
-                    data_point_key="batt", value=6.0, unit=PERCENTAGE
+                    data_point_key="batt", value=120, unit=PERCENTAGE
                 ),
                 "wh90batt": CalculatedDataPoint(
                     data_point_key="batt", value=3.22, unit=ELECTRIC_POTENTIAL_VOLT
@@ -752,7 +752,7 @@ def test_missing_distance(device_data_gw2000a_1, ecowitt, request):
                     data_point_key="batt", value=1.5, unit=ELECTRIC_POTENTIAL_VOLT
                 ),
                 "pm25batt1": CalculatedDataPoint(
-                    data_point_key="batt", value=5.0, unit=PERCENTAGE
+                    data_point_key="batt", value=100, unit=PERCENTAGE
                 ),
                 "dewpoint": CalculatedDataPoint("dewpoint", 49.8, unit=TEMP_FAHRENHEIT),
                 "feelslike": CalculatedDataPoint(


### PR DESCRIPTION
**Describe what the PR does:**

It turns out that percentage battery values need to be multiplied by 20 to get their real value (e.g., a value of `2` really means `40%`).

**Does this fix a specific issue?**

Related to https://github.com/bachya/ecowitt2mqtt/issues/155

**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
