### PR TITLE
Fix issue where Uvicorn logs didn't correspond to verbose mode

### DIFF
--- a/ecowitt2mqtt/config.py
+++ b/ecowitt2mqtt/config.py
@@ -24,6 +24,7 @@ from ecowitt2mqtt.const import (
     CONF_OUTPUT_UNIT_SYSTEM,
     CONF_PORT,
     CONF_RAW_DATA,
+    CONF_VERBOSE,
     ENV_BATTERY_OVERRIDE,
     ENV_ENDPOINT,
     ENV_HASS_DISCOVERY,
@@ -244,3 +245,8 @@ class Config:
     def raw_data(self) -> bool:
         """Return whether raw data is configured."""
         return cast(bool, self._config[CONF_RAW_DATA])
+
+    @property
+    def verbose(self) -> bool:
+        """Return whether verbose logging is enabled."""
+        return cast(bool, self._config[CONF_VERBOSE])

--- a/ecowitt2mqtt/config.py
+++ b/ecowitt2mqtt/config.py
@@ -169,27 +169,29 @@ class Config:
     @property
     def battery_overrides(self) -> dict[str, BatteryStrategy]:
         """Return the battery overrides."""
-        return cast(Dict[str, BatteryStrategy], self._config[CONF_BATTERY_OVERRIDES])
+        return cast(
+            Dict[str, BatteryStrategy], self._config.get(CONF_BATTERY_OVERRIDES)
+        )
 
     @property
     def default_battery_strategy(self) -> BatteryStrategy:
         """Return the default battery strategy."""
-        return cast(BatteryStrategy, self._config[CONF_DEFAULT_BATTERY_STRATEGY])
+        return cast(BatteryStrategy, self._config.get(CONF_DEFAULT_BATTERY_STRATEGY))
 
     @property
     def endpoint(self) -> str:
         """Return the ecowitt2mqtt API endpoint."""
-        return cast(str, self._config[CONF_ENDPOINT])
+        return cast(str, self._config.get(CONF_ENDPOINT))
 
     @property
     def hass_discovery(self) -> bool:
         """Return whether Home Assistant Discovery should be used."""
-        return cast(bool, self._config[CONF_HASS_DISCOVERY])
+        return cast(bool, self._config.get(CONF_HASS_DISCOVERY))
 
     @property
     def hass_discovery_prefix(self) -> str:
         """Return the Home Assistant Discovery MQTT prefix."""
-        return cast(str, self._config[CONF_HASS_DISCOVERY_PREFIX])
+        return cast(str, self._config.get(CONF_HASS_DISCOVERY_PREFIX))
 
     @property
     def hass_entity_id_prefix(self) -> str | None:
@@ -199,22 +201,22 @@ class Config:
     @property
     def input_unit_system(self) -> UnitSystemType:
         """Return the input unit system."""
-        return cast(UnitSystemType, self._config[CONF_INPUT_UNIT_SYSTEM])
+        return cast(UnitSystemType, self._config.get(CONF_INPUT_UNIT_SYSTEM))
 
     @property
     def mqtt_broker(self) -> str:
         """Return the MQTT broker host/IP address."""
-        return cast(str, self._config[CONF_MQTT_BROKER])
+        return cast(str, self._config.get(CONF_MQTT_BROKER))
 
     @property
     def mqtt_password(self) -> str:
         """Return the MQTT broker password."""
-        return cast(str, self._config[CONF_MQTT_PASSWORD])
+        return cast(str, self._config.get(CONF_MQTT_PASSWORD))
 
     @property
     def mqtt_port(self) -> int:
         """Return the MQTT broker port."""
-        return cast(int, self._config[CONF_MQTT_PORT])
+        return cast(int, self._config.get(CONF_MQTT_PORT))
 
     @property
     def mqtt_tls(self) -> bool:
@@ -229,24 +231,24 @@ class Config:
     @property
     def mqtt_username(self) -> str:
         """Return the MQTT broker username."""
-        return cast(str, self._config[CONF_MQTT_USERNAME])
+        return cast(str, self._config.get(CONF_MQTT_USERNAME))
 
     @property
     def output_unit_system(self) -> UnitSystemType:
         """Return the output unit system."""
-        return cast(UnitSystemType, self._config[CONF_OUTPUT_UNIT_SYSTEM])
+        return cast(UnitSystemType, self._config.get(CONF_OUTPUT_UNIT_SYSTEM))
 
     @property
     def port(self) -> int:
         """Return the ecowitt2mqtt API port."""
-        return cast(int, self._config[CONF_PORT])
+        return cast(int, self._config.get(CONF_PORT))
 
     @property
     def raw_data(self) -> bool:
         """Return whether raw data is configured."""
-        return cast(bool, self._config[CONF_RAW_DATA])
+        return cast(bool, self._config.get(CONF_RAW_DATA))
 
     @property
     def verbose(self) -> bool:
         """Return whether verbose logging is enabled."""
-        return cast(bool, self._config[CONF_VERBOSE])
+        return cast(bool, self._config.get(CONF_VERBOSE))

--- a/ecowitt2mqtt/server.py
+++ b/ecowitt2mqtt/server.py
@@ -13,8 +13,10 @@ from ecowitt2mqtt.util import execute_callback
 if TYPE_CHECKING:
     from ecowitt2mqtt.core import Ecowitt
 
-DEFAULT_SERVER_LOG_LEVEL = "error"
 DEFAULT_HOST = "0.0.0.0"
+
+SERVER_LOG_LEVEL_DEBUG = "debug"
+SERVER_LOG_LEVEL_ERROR = "error"
 
 
 class Server:
@@ -34,6 +36,13 @@ class Server:
         )(self._post_data)
 
         self.ecowitt = ecowitt
+
+    @property
+    def log_level(self) -> str:
+        """Return the server log level."""
+        if self.ecowitt.config.verbose:
+            return SERVER_LOG_LEVEL_DEBUG
+        return SERVER_LOG_LEVEL_ERROR
 
     async def _post_data(self, request: Request) -> Response:
         """Define an endpoint for the Ecowitt device to post data to."""
@@ -69,7 +78,7 @@ class Server:
                 self.app,
                 host=DEFAULT_HOST,
                 port=self.ecowitt.config.port,
-                log_level=DEFAULT_SERVER_LOG_LEVEL,
+                log_level=self.log_level,
                 loop=loop,
             )
         )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -7,9 +7,57 @@ from aiohttp import ClientSession
 from fastapi.datastructures import FormData
 import pytest
 
+from ecowitt2mqtt.const import (
+    CONF_ENDPOINT,
+    CONF_MQTT_BROKER,
+    CONF_MQTT_PASSWORD,
+    CONF_MQTT_TOPIC,
+    CONF_MQTT_USERNAME,
+    CONF_VERBOSE,
+)
 from ecowitt2mqtt.core import Ecowitt
 
-from tests.common import TEST_ENDPOINT, TEST_PORT
+from tests.common import (
+    TEST_ENDPOINT,
+    TEST_MQTT_BROKER,
+    TEST_MQTT_PASSWORD,
+    TEST_MQTT_TOPIC,
+    TEST_MQTT_USERNAME,
+    TEST_PORT,
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "config,log_level",
+    [
+        (
+            {
+                CONF_ENDPOINT: TEST_ENDPOINT,
+                CONF_MQTT_BROKER: TEST_MQTT_BROKER,
+                CONF_MQTT_PASSWORD: TEST_MQTT_PASSWORD,
+                CONF_MQTT_TOPIC: TEST_MQTT_TOPIC,
+                CONF_MQTT_USERNAME: TEST_MQTT_USERNAME,
+                CONF_VERBOSE: False,
+            },
+            "error",
+        ),
+        (
+            {
+                CONF_ENDPOINT: TEST_ENDPOINT,
+                CONF_MQTT_BROKER: TEST_MQTT_BROKER,
+                CONF_MQTT_PASSWORD: TEST_MQTT_PASSWORD,
+                CONF_MQTT_TOPIC: TEST_MQTT_TOPIC,
+                CONF_MQTT_USERNAME: TEST_MQTT_USERNAME,
+                CONF_VERBOSE: True,
+            },
+            "debug",
+        ),
+    ],
+)
+async def test_log_levels(device_data, ecowitt, log_level):
+    """Test that server log levels are set correctly."""
+    assert ecowitt.server.log_level == log_level
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**Describe what the PR does:**

Uvicorn logs were always set to `ERROR`-level, even when verbose mode was activated. This PR fixes that.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
