### PR TITLE
Ensure raw payload is logged as a dict

### DIFF
--- a/ecowitt2mqtt/server.py
+++ b/ecowitt2mqtt/server.py
@@ -51,7 +51,7 @@ class Server:
     async def _async_post_data(self, request: Request) -> Response:
         """Define an endpoint for the Ecowitt device to post data to."""
         payload = await request.form()
-        LOGGER.debug("Received data from the Ecowitt device: %s", payload)
+        LOGGER.debug("Received data from the Ecowitt device: %s", dict(payload))
         for callback in self._device_payload_callbacks:
             if asyncio.iscoroutinefunction(callback):
                 self._loop.create_task(callback(payload))  # type: ignore


### PR DESCRIPTION
**Describe what the PR does:**

Currently, the raw payload is logged as FormData, which is not as easy to parse. This PR adjust things so it is logged as a dict instead.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
