### PR TITLE
Fix bug where diagnostics would erroneously activate with verbose

### DIFF
--- a/ecowitt2mqtt/config.py
+++ b/ecowitt2mqtt/config.py
@@ -10,6 +10,7 @@ from ecowitt2mqtt.const import (
     CONF_BATTERY_OVERRIDES,
     CONF_CONFIG,
     CONF_DEFAULT_BATTERY_STRATEGY,
+    CONF_DIAGNOSTICS,
     CONF_ENDPOINT,
     CONF_HASS_DISCOVERY,
     CONF_HASS_DISCOVERY_PREFIX,
@@ -181,7 +182,7 @@ class Config:
     @property
     def diagnostics(self) -> bool:
         """Return whether diagnostics is enabled."""
-        return cast(bool, self._config.get(CONF_VERBOSE))
+        return cast(bool, self._config.get(CONF_DIAGNOSTICS))
 
     @property
     def endpoint(self) -> str:


### PR DESCRIPTION
**Describe what the PR does:**

https://github.com/bachya/ecowitt2mqtt/issues/182 revealed that I was accidentally activating diagnostics when `verbose` was true. 🤦🏻 This PR fixes the bug. 

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
