### PR TITLE
Bump `build-base` in Dockerfile to 0.5-r3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /app
 # hadolint ignore=DL3013
 RUN apk add --no-cache \
         bash==5.1.16-r2 \
-        build-base==0.5-r2 \
+        build-base==0.5-r3 \
         cargo==1.60.0-r2 \
         gcc==11.2.1_git20220219-r2 \
         libffi-dev==3.4.2-r1 \


### PR DESCRIPTION
**Describe what the PR does:**

Looks like Alpine published a new version and requires it for Docker builds to pass.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
