### PR TITLE
Unpin Alpine requirements in builder Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,16 +8,16 @@ ENV PIP_DEFAULT_TIMEOUT=100 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PIP_NO_CACHE_DIR=1
 WORKDIR /app
-# hadolint ignore=DL3013
+# hadolint ignore=DL3018,DL3013
 RUN apk add --no-cache \
-        bash==5.1.16-r2 \
-        build-base==0.5-r3 \
-        cargo==1.60.0-r2 \
-        gcc==11.2.1_git20220219-r2 \
-        libffi-dev==3.4.2-r1 \
-        musl-dev==1.2.3-r0 \
-        openssl-dev==1.1.1o-r0 \
-        python3-dev==3.10.4-r0 \
+        bash \
+        build-base \
+        cargo \
+        gcc \
+        libffi-dev \
+        musl-dev \
+        openssl-dev \
+        python3-dev \
     && python3 -m pip install --upgrade \
         cryptography==37.0.2 \
         pip \


### PR DESCRIPTION
**Describe what the PR does:**

We currently pin Alpine package version requirements, but that's turning out to be an issue: when packages are updated, the version pinning can break, which causes the entire Docker build process to break (and I don't know about it until I go to merge something to `dev`). Since this affects the intermediate "builder" image, version pinning isn't strictly necessary – so, this PR removes them in the hope that `apk` will just resolve things the correct way.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
