### PR TITLE
Add additional Docker image architectures

### DIFF
--- a/.github/workflows/publish_to_docker_hub.yaml
+++ b/.github/workflows/publish_to_docker_hub.yaml
@@ -62,6 +62,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: >
+            linux/aarch64,linux/amd64,linux/armhf,linux/arm64
           push: true
           tags: ${{ steps.prep.outputs.tags }}

--- a/.github/workflows/publish_to_docker_hub.yaml
+++ b/.github/workflows/publish_to_docker_hub.yaml
@@ -62,7 +62,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: >
+          platforms: >-
             linux/aarch64,linux/amd64,linux/armhf,linux/arm64
           push: true
           tags: ${{ steps.prep.outputs.tags }}


### PR DESCRIPTION
**Describe what the PR does:**

In prep to build an official Home Assistant OS add-on, this PR adds additional Docker image architectures:

- `aarch64`
- `armhf`

We'll need to merge this into `dev` to test, so if it fails, we'll revert this PR.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
