### PR TITLE
Add calculated sensors for safe exposure to UV indices

### DIFF
--- a/ecowitt2mqtt/const.py
+++ b/ecowitt2mqtt/const.py
@@ -75,6 +75,12 @@ DATA_POINT_MONTHLY_RAIN: Final = "monthlyrain"
 DATA_POINT_MRAIN_PIEZO: Final = "mrain_piezo"
 DATA_POINT_RAIN_RATE: Final = "rainrate"
 DATA_POINT_RUNTIME: Final = "runtime"
+DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_1: Final = "safe_exposure_time_skin_type_1"
+DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_2: Final = "safe_exposure_time_skin_type_2"
+DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_3: Final = "safe_exposure_time_skin_type_3"
+DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_4: Final = "safe_exposure_time_skin_type_4"
+DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_5: Final = "safe_exposure_time_skin_type_5"
+DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_6: Final = "safe_exposure_time_skin_type_6"
 DATA_POINT_SOLARRADIATION: Final = "solarradiation"
 DATA_POINT_SOLARRADIATION_LUX: Final = "solarradiation_lux"
 DATA_POINT_SOLARRADIATION_PERCEIVED: Final = "solarradiation_perceived"
@@ -180,6 +186,7 @@ TEMP_CELSIUS: Final = "°C"
 TEMP_FAHRENHEIT: Final = "°F"
 
 # Time units
+TIME_MINUTES: Final = "min"
 TIME_SECONDS: Final = "s"
 
 # UV units:

--- a/ecowitt2mqtt/data.py
+++ b/ecowitt2mqtt/data.py
@@ -35,6 +35,12 @@ from ecowitt2mqtt.const import (
     DATA_POINT_LIGHTNING_TIME,
     DATA_POINT_RAIN_RATE,
     DATA_POINT_RUNTIME,
+    DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_1,
+    DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_2,
+    DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_3,
+    DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_4,
+    DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_5,
+    DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_6,
     DATA_POINT_SOLARRADIATION,
     DATA_POINT_SOLARRADIATION_LUX,
     DATA_POINT_SOLARRADIATION_PERCEIVED,
@@ -63,6 +69,7 @@ from ecowitt2mqtt.helpers.calculator.meteo import (
     calculate_pressure,
     calculate_rain_rate,
     calculate_rain_volume,
+    calculate_safe_exposure_time,
     calculate_solar_radiation_lux,
     calculate_solar_radiation_perceived,
     calculate_solar_radiation_wm2,
@@ -97,6 +104,7 @@ CALCULATOR_FUNCTION_MAP: dict[str, Callable[..., CalculatedDataPoint]] = {
     DATA_POINT_GLOB_PM10: calculate_pm10,
     DATA_POINT_GLOB_PM25: calculate_pm25,
     DATA_POINT_GLOB_RAIN: calculate_rain_volume,
+    DATA_POINT_GLOB_R_RAIN: calculate_rain_rate,
     DATA_POINT_GLOB_TEMP: calculate_temperature,
     DATA_POINT_GLOB_TF: calculate_temperature,
     DATA_POINT_GLOB_VOLT: calculate_battery,
@@ -110,7 +118,12 @@ CALCULATOR_FUNCTION_MAP: dict[str, Callable[..., CalculatedDataPoint]] = {
     DATA_POINT_LIGHTNING_TIME: calculate_dt_from_epoch,
     DATA_POINT_RAIN_RATE: calculate_rain_rate,
     DATA_POINT_RUNTIME: calculate_runtime,
-    DATA_POINT_GLOB_R_RAIN: calculate_rain_rate,
+    DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_1: calculate_safe_exposure_time,
+    DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_2: calculate_safe_exposure_time,
+    DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_3: calculate_safe_exposure_time,
+    DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_4: calculate_safe_exposure_time,
+    DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_5: calculate_safe_exposure_time,
+    DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_6: calculate_safe_exposure_time,
     DATA_POINT_SOLARRADIATION: calculate_solar_radiation_wm2,
     DATA_POINT_SOLARRADIATION_LUX: calculate_solar_radiation_lux,
     DATA_POINT_SOLARRADIATION_PERCEIVED: calculate_solar_radiation_perceived,
@@ -146,6 +159,7 @@ FEELS_LIKE_KEYS = (DATA_POINT_TEMPF, DATA_POINT_HUMIDITY, DATA_POINT_WINDSPEEDMP
 HEAT_INDEX_KEYS = (DATA_POINT_TEMPF, DATA_POINT_HUMIDITY)
 WIND_CHILL_KEYS = (DATA_POINT_TEMPF, DATA_POINT_WINDSPEEDMPH)
 ILLUMINANCE_KEYS = (DATA_POINT_SOLARRADIATION,)
+UV_INDEX_KEYS = (DATA_POINT_UV,)
 
 T = TypeVar("T")
 
@@ -226,6 +240,12 @@ class ProcessedData:
             (DATA_POINT_DEWPOINT, DEW_POINT_KEYS),
             (DATA_POINT_FEELSLIKE, FEELS_LIKE_KEYS),
             (DATA_POINT_HEATINDEX, HEAT_INDEX_KEYS),
+            (DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_1, UV_INDEX_KEYS),
+            (DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_2, UV_INDEX_KEYS),
+            (DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_3, UV_INDEX_KEYS),
+            (DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_4, UV_INDEX_KEYS),
+            (DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_5, UV_INDEX_KEYS),
+            (DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_6, UV_INDEX_KEYS),
             (DATA_POINT_SOLARRADIATION_LUX, ILLUMINANCE_KEYS),
             (DATA_POINT_SOLARRADIATION_PERCEIVED, ILLUMINANCE_KEYS),
             (DATA_POINT_WINDCHILL, WIND_CHILL_KEYS),

--- a/ecowitt2mqtt/helpers/calculator/meteo.py
+++ b/ecowitt2mqtt/helpers/calculator/meteo.py
@@ -9,6 +9,12 @@ import meteocalc
 from ecowitt2mqtt.const import (
     CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     CONCENTRATION_PARTS_PER_MILLION,
+    DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_1,
+    DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_2,
+    DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_3,
+    DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_4,
+    DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_5,
+    DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_6,
     DEGREE,
     DISTANCE_KILOMETERS,
     DISTANCE_MILES,
@@ -25,6 +31,7 @@ from ecowitt2mqtt.const import (
     STRIKES,
     TEMP_CELSIUS,
     TEMP_FAHRENHEIT,
+    TIME_MINUTES,
     UNIT_SYSTEM_IMPERIAL,
     UNIT_SYSTEM_METRIC,
     UV_INDEX,
@@ -58,6 +65,15 @@ TEMP_UNIT_MAP = {
 WIND_SPEED_UNIT_MAP = {
     UNIT_SYSTEM_IMPERIAL: SPEED_MILES_PER_HOUR,
     UNIT_SYSTEM_METRIC: SPEED_KILOMETERS_PER_HOUR,
+}
+
+SAFE_EXPOSURE_CONSTANT_MAP: dict[str, float] = {
+    DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_1: 2.5,
+    DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_2: 3.0,
+    DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_3: 4.0,
+    DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_4: 5.0,
+    DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_5: 8.0,
+    DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_6: 13.0,
 }
 
 
@@ -258,6 +274,21 @@ def calculate_rain_volume(
         data_point_key=data_point_key,
         value=final_value,
         unit=RAIN_VOLUME_UNIT_MAP[ecowitt.config.output_unit_system],
+    )
+
+
+def calculate_safe_exposure_time(
+    ecowitt: Ecowitt, payload_key: str, data_point_key: str, *, uv: float
+) -> CalculatedDataPoint:
+    """Calculate the number of minutes one can be safely exposed to a UV index."""
+    try:
+        final_value = round(
+            (200 * SAFE_EXPOSURE_CONSTANT_MAP[payload_key]) / (3 * uv), 1
+        )
+    except ZeroDivisionError:
+        final_value = None
+    return CalculatedDataPoint(
+        data_point_key=data_point_key, value=final_value, unit=TIME_MINUTES
     )
 
 

--- a/ecowitt2mqtt/helpers/publisher/hass.py
+++ b/ecowitt2mqtt/helpers/publisher/hass.py
@@ -44,6 +44,12 @@ from ecowitt2mqtt.const import (
     DATA_POINT_MRAIN_PIEZO,
     DATA_POINT_RAIN_RATE,
     DATA_POINT_RUNTIME,
+    DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_1,
+    DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_2,
+    DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_3,
+    DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_4,
+    DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_5,
+    DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_6,
     DATA_POINT_SOLARRADIATION,
     DATA_POINT_SOLARRADIATION_LUX,
     DATA_POINT_SOLARRADIATION_PERCEIVED,
@@ -258,6 +264,30 @@ ENTITY_DESCRIPTIONS = {
     ),
     DATA_POINT_LIGHTNING_TIME: EntityDescription(
         device_class=DeviceClass.TIMESTAMP,
+        state_class=StateClass.MEASUREMENT,
+    ),
+    DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_1: EntityDescription(
+        icon="mdi:timer",
+        state_class=StateClass.MEASUREMENT,
+    ),
+    DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_2: EntityDescription(
+        icon="mdi:timer",
+        state_class=StateClass.MEASUREMENT,
+    ),
+    DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_3: EntityDescription(
+        icon="mdi:timer",
+        state_class=StateClass.MEASUREMENT,
+    ),
+    DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_4: EntityDescription(
+        icon="mdi:timer",
+        state_class=StateClass.MEASUREMENT,
+    ),
+    DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_5: EntityDescription(
+        icon="mdi:timer",
+        state_class=StateClass.MEASUREMENT,
+    ),
+    DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_6: EntityDescription(
+        icon="mdi:timer",
         state_class=StateClass.MEASUREMENT,
     ),
     DATA_POINT_SOLARRADIATION: EntityDescription(

--- a/tests/publisher/test_hass_discovery.py
+++ b/tests/publisher/test_hass_discovery.py
@@ -1074,6 +1074,78 @@ async def test_publish(config, device_data, ecowitt, request, setup_asyncio_mqtt
                 b"58.4",
             ),
             call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_1/config",
+                b'{"availability_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_1/availability", "device": {"identifiers": ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"], "manufacturer": "Ecowitt", "model": "GW2000A", "name": "GW2000A", "sw_version": "GW2000A_V2.1.4"}, "name": "safe_exposure_time_skin_type_1", "qos": 1, "state_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_1/state", "unique_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_safe_exposure_time_skin_type_1", "unit_of_measurement": "min", "icon": "mdi:timer", "state_class": "measurement"}',
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_1/availability",
+                b"offline",
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_1/state",
+                b"None",
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_2/config",
+                b'{"availability_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_2/availability", "device": {"identifiers": ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"], "manufacturer": "Ecowitt", "model": "GW2000A", "name": "GW2000A", "sw_version": "GW2000A_V2.1.4"}, "name": "safe_exposure_time_skin_type_2", "qos": 1, "state_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_2/state", "unique_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_safe_exposure_time_skin_type_2", "unit_of_measurement": "min", "icon": "mdi:timer", "state_class": "measurement"}',
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_2/availability",
+                b"offline",
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_2/state",
+                b"None",
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_3/config",
+                b'{"availability_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_3/availability", "device": {"identifiers": ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"], "manufacturer": "Ecowitt", "model": "GW2000A", "name": "GW2000A", "sw_version": "GW2000A_V2.1.4"}, "name": "safe_exposure_time_skin_type_3", "qos": 1, "state_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_3/state", "unique_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_safe_exposure_time_skin_type_3", "unit_of_measurement": "min", "icon": "mdi:timer", "state_class": "measurement"}',
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_3/availability",
+                b"offline",
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_3/state",
+                b"None",
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_4/config",
+                b'{"availability_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_4/availability", "device": {"identifiers": ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"], "manufacturer": "Ecowitt", "model": "GW2000A", "name": "GW2000A", "sw_version": "GW2000A_V2.1.4"}, "name": "safe_exposure_time_skin_type_4", "qos": 1, "state_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_4/state", "unique_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_safe_exposure_time_skin_type_4", "unit_of_measurement": "min", "icon": "mdi:timer", "state_class": "measurement"}',
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_4/availability",
+                b"offline",
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_4/state",
+                b"None",
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_5/config",
+                b'{"availability_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_5/availability", "device": {"identifiers": ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"], "manufacturer": "Ecowitt", "model": "GW2000A", "name": "GW2000A", "sw_version": "GW2000A_V2.1.4"}, "name": "safe_exposure_time_skin_type_5", "qos": 1, "state_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_5/state", "unique_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_safe_exposure_time_skin_type_5", "unit_of_measurement": "min", "icon": "mdi:timer", "state_class": "measurement"}',
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_5/availability",
+                b"offline",
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_5/state",
+                b"None",
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_6/config",
+                b'{"availability_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_6/availability", "device": {"identifiers": ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"], "manufacturer": "Ecowitt", "model": "GW2000A", "name": "GW2000A", "sw_version": "GW2000A_V2.1.4"}, "name": "safe_exposure_time_skin_type_6", "qos": 1, "state_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_6/state", "unique_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_safe_exposure_time_skin_type_6", "unit_of_measurement": "min", "icon": "mdi:timer", "state_class": "measurement"}',
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_6/availability",
+                b"offline",
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_6/state",
+                b"None",
+            ),
+            call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/solarradiation_lux/config",
                 b'{"availability_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/solarradiation_lux/availability", "device": {"identifiers": ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"], "manufacturer": "Ecowitt", "model": "GW2000A", "name": "GW2000A", "sw_version": "GW2000A_V2.1.4"}, "name": "solarradiation_lux", "qos": 1, "state_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/solarradiation_lux/state", "unique_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_solarradiation_lux", "unit_of_measurement": "lx", "device_class": "illuminance", "state_class": "measurement"}',
             ),
@@ -2138,6 +2210,78 @@ async def test_publish_custom_entity_id_prefix(
                 b"58.4",
             ),
             call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_1/config",
+                b'{"availability_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_1/availability", "device": {"identifiers": ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"], "manufacturer": "Ecowitt", "model": "GW2000A", "name": "GW2000A", "sw_version": "GW2000A_V2.1.4"}, "name": "test_prefix_safe_exposure_time_skin_type_1", "qos": 1, "state_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_1/state", "unique_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_safe_exposure_time_skin_type_1", "unit_of_measurement": "min", "icon": "mdi:timer", "state_class": "measurement"}',
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_1/availability",
+                b"offline",
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_1/state",
+                b"None",
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_2/config",
+                b'{"availability_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_2/availability", "device": {"identifiers": ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"], "manufacturer": "Ecowitt", "model": "GW2000A", "name": "GW2000A", "sw_version": "GW2000A_V2.1.4"}, "name": "test_prefix_safe_exposure_time_skin_type_2", "qos": 1, "state_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_2/state", "unique_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_safe_exposure_time_skin_type_2", "unit_of_measurement": "min", "icon": "mdi:timer", "state_class": "measurement"}',
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_2/availability",
+                b"offline",
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_2/state",
+                b"None",
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_3/config",
+                b'{"availability_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_3/availability", "device": {"identifiers": ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"], "manufacturer": "Ecowitt", "model": "GW2000A", "name": "GW2000A", "sw_version": "GW2000A_V2.1.4"}, "name": "test_prefix_safe_exposure_time_skin_type_3", "qos": 1, "state_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_3/state", "unique_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_safe_exposure_time_skin_type_3", "unit_of_measurement": "min", "icon": "mdi:timer", "state_class": "measurement"}',
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_3/availability",
+                b"offline",
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_3/state",
+                b"None",
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_4/config",
+                b'{"availability_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_4/availability", "device": {"identifiers": ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"], "manufacturer": "Ecowitt", "model": "GW2000A", "name": "GW2000A", "sw_version": "GW2000A_V2.1.4"}, "name": "test_prefix_safe_exposure_time_skin_type_4", "qos": 1, "state_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_4/state", "unique_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_safe_exposure_time_skin_type_4", "unit_of_measurement": "min", "icon": "mdi:timer", "state_class": "measurement"}',
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_4/availability",
+                b"offline",
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_4/state",
+                b"None",
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_5/config",
+                b'{"availability_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_5/availability", "device": {"identifiers": ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"], "manufacturer": "Ecowitt", "model": "GW2000A", "name": "GW2000A", "sw_version": "GW2000A_V2.1.4"}, "name": "test_prefix_safe_exposure_time_skin_type_5", "qos": 1, "state_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_5/state", "unique_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_safe_exposure_time_skin_type_5", "unit_of_measurement": "min", "icon": "mdi:timer", "state_class": "measurement"}',
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_5/availability",
+                b"offline",
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_5/state",
+                b"None",
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_6/config",
+                b'{"availability_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_6/availability", "device": {"identifiers": ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"], "manufacturer": "Ecowitt", "model": "GW2000A", "name": "GW2000A", "sw_version": "GW2000A_V2.1.4"}, "name": "test_prefix_safe_exposure_time_skin_type_6", "qos": 1, "state_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_6/state", "unique_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_safe_exposure_time_skin_type_6", "unit_of_measurement": "min", "icon": "mdi:timer", "state_class": "measurement"}',
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_6/availability",
+                b"offline",
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_6/state",
+                b"None",
+            ),
+            call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/solarradiation_lux/config",
                 b'{"availability_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/solarradiation_lux/availability", "device": {"identifiers": ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"], "manufacturer": "Ecowitt", "model": "GW2000A", "name": "GW2000A", "sw_version": "GW2000A_V2.1.4"}, "name": "test_prefix_solarradiation_lux", "qos": 1, "state_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/solarradiation_lux/state", "unique_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_solarradiation_lux", "unit_of_measurement": "lx", "device_class": "illuminance", "state_class": "measurement"}',
             ),
@@ -3199,6 +3343,78 @@ async def test_publish_numeric_battery_strategy(
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/heatindex/state",
                 b"58.4",
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_1/config",
+                b'{"availability_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_1/availability", "device": {"identifiers": ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"], "manufacturer": "Ecowitt", "model": "GW2000A", "name": "GW2000A", "sw_version": "GW2000A_V2.1.4"}, "name": "safe_exposure_time_skin_type_1", "qos": 1, "state_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_1/state", "unique_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_safe_exposure_time_skin_type_1", "unit_of_measurement": "min", "icon": "mdi:timer", "state_class": "measurement"}',
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_1/availability",
+                b"offline",
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_1/state",
+                b"None",
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_2/config",
+                b'{"availability_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_2/availability", "device": {"identifiers": ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"], "manufacturer": "Ecowitt", "model": "GW2000A", "name": "GW2000A", "sw_version": "GW2000A_V2.1.4"}, "name": "safe_exposure_time_skin_type_2", "qos": 1, "state_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_2/state", "unique_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_safe_exposure_time_skin_type_2", "unit_of_measurement": "min", "icon": "mdi:timer", "state_class": "measurement"}',
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_2/availability",
+                b"offline",
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_2/state",
+                b"None",
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_3/config",
+                b'{"availability_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_3/availability", "device": {"identifiers": ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"], "manufacturer": "Ecowitt", "model": "GW2000A", "name": "GW2000A", "sw_version": "GW2000A_V2.1.4"}, "name": "safe_exposure_time_skin_type_3", "qos": 1, "state_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_3/state", "unique_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_safe_exposure_time_skin_type_3", "unit_of_measurement": "min", "icon": "mdi:timer", "state_class": "measurement"}',
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_3/availability",
+                b"offline",
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_3/state",
+                b"None",
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_4/config",
+                b'{"availability_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_4/availability", "device": {"identifiers": ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"], "manufacturer": "Ecowitt", "model": "GW2000A", "name": "GW2000A", "sw_version": "GW2000A_V2.1.4"}, "name": "safe_exposure_time_skin_type_4", "qos": 1, "state_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_4/state", "unique_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_safe_exposure_time_skin_type_4", "unit_of_measurement": "min", "icon": "mdi:timer", "state_class": "measurement"}',
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_4/availability",
+                b"offline",
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_4/state",
+                b"None",
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_5/config",
+                b'{"availability_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_5/availability", "device": {"identifiers": ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"], "manufacturer": "Ecowitt", "model": "GW2000A", "name": "GW2000A", "sw_version": "GW2000A_V2.1.4"}, "name": "safe_exposure_time_skin_type_5", "qos": 1, "state_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_5/state", "unique_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_safe_exposure_time_skin_type_5", "unit_of_measurement": "min", "icon": "mdi:timer", "state_class": "measurement"}',
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_5/availability",
+                b"offline",
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_5/state",
+                b"None",
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_6/config",
+                b'{"availability_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_6/availability", "device": {"identifiers": ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"], "manufacturer": "Ecowitt", "model": "GW2000A", "name": "GW2000A", "sw_version": "GW2000A_V2.1.4"}, "name": "safe_exposure_time_skin_type_6", "qos": 1, "state_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_6/state", "unique_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_safe_exposure_time_skin_type_6", "unit_of_measurement": "min", "icon": "mdi:timer", "state_class": "measurement"}',
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_6/availability",
+                b"offline",
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_6/state",
+                b"None",
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/solarradiation_lux/config",
@@ -4303,6 +4519,78 @@ async def test_no_entity_description(caplog, device_data, ecowitt, setup_asyncio
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/heatindex/state",
                 b"58.4",
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_1/config",
+                b'{"availability_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_1/availability", "device": {"identifiers": ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"], "manufacturer": "Ecowitt", "model": "GW2000A", "name": "GW2000A", "sw_version": "GW2000A_V2.1.4"}, "name": "safe_exposure_time_skin_type_1", "qos": 1, "state_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_1/state", "unique_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_safe_exposure_time_skin_type_1", "unit_of_measurement": "min", "icon": "mdi:timer", "state_class": "measurement"}',
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_1/availability",
+                b"offline",
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_1/state",
+                b"None",
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_2/config",
+                b'{"availability_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_2/availability", "device": {"identifiers": ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"], "manufacturer": "Ecowitt", "model": "GW2000A", "name": "GW2000A", "sw_version": "GW2000A_V2.1.4"}, "name": "safe_exposure_time_skin_type_2", "qos": 1, "state_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_2/state", "unique_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_safe_exposure_time_skin_type_2", "unit_of_measurement": "min", "icon": "mdi:timer", "state_class": "measurement"}',
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_2/availability",
+                b"offline",
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_2/state",
+                b"None",
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_3/config",
+                b'{"availability_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_3/availability", "device": {"identifiers": ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"], "manufacturer": "Ecowitt", "model": "GW2000A", "name": "GW2000A", "sw_version": "GW2000A_V2.1.4"}, "name": "safe_exposure_time_skin_type_3", "qos": 1, "state_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_3/state", "unique_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_safe_exposure_time_skin_type_3", "unit_of_measurement": "min", "icon": "mdi:timer", "state_class": "measurement"}',
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_3/availability",
+                b"offline",
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_3/state",
+                b"None",
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_4/config",
+                b'{"availability_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_4/availability", "device": {"identifiers": ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"], "manufacturer": "Ecowitt", "model": "GW2000A", "name": "GW2000A", "sw_version": "GW2000A_V2.1.4"}, "name": "safe_exposure_time_skin_type_4", "qos": 1, "state_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_4/state", "unique_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_safe_exposure_time_skin_type_4", "unit_of_measurement": "min", "icon": "mdi:timer", "state_class": "measurement"}',
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_4/availability",
+                b"offline",
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_4/state",
+                b"None",
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_5/config",
+                b'{"availability_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_5/availability", "device": {"identifiers": ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"], "manufacturer": "Ecowitt", "model": "GW2000A", "name": "GW2000A", "sw_version": "GW2000A_V2.1.4"}, "name": "safe_exposure_time_skin_type_5", "qos": 1, "state_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_5/state", "unique_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_safe_exposure_time_skin_type_5", "unit_of_measurement": "min", "icon": "mdi:timer", "state_class": "measurement"}',
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_5/availability",
+                b"offline",
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_5/state",
+                b"None",
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_6/config",
+                b'{"availability_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_6/availability", "device": {"identifiers": ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"], "manufacturer": "Ecowitt", "model": "GW2000A", "name": "GW2000A", "sw_version": "GW2000A_V2.1.4"}, "name": "safe_exposure_time_skin_type_6", "qos": 1, "state_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_6/state", "unique_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_safe_exposure_time_skin_type_6", "unit_of_measurement": "min", "icon": "mdi:timer", "state_class": "measurement"}',
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_6/availability",
+                b"offline",
+            ),
+            call(
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_6/state",
+                b"None",
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/solarradiation_lux/config",

--- a/tests/publisher/test_topic_publisher.py
+++ b/tests/publisher/test_topic_publisher.py
@@ -28,7 +28,7 @@ async def test_publish(config, device_data, ecowitt, request, setup_asyncio_mqtt
 
     publisher.client.publish.assert_awaited_with(
         TEST_MQTT_TOPIC,
-        b'{"runtime": 319206.0, "tempin": 79.5, "humidityin": 31.0, "baromrel": 24.74, "baromabs": 24.74, "temp": 19.1, "humidity": 34.0, "winddir": 139.0, "windspeed": 20.89, "windgust": 1.12, "maxdailygust": 8.05, "solarradiation": 264.61, "uv": 2.0, "rainrate": 0.0, "eventrain": 0.0, "hourlyrain": 0.0, "dailyrain": 0.0, "weeklyrain": 0.0, "monthlyrain": 2.177, "yearlyrain": 4.441, "lightning_num": 13.0, "lightning": 0.6, "lightning_time": "2022-04-20T17:17:17+00:00", "wh65batt": "OFF", "dewpoint": -4.7, "feelslike": 2.7, "heatindex": 12.3, "solarradiation_lux": 33494.9, "solarradiation_perceived": 90.0, "windchill": 2.7}',
+        b'{"runtime": 319206.0, "tempin": 79.5, "humidityin": 31.0, "baromrel": 24.74, "baromabs": 24.74, "temp": 19.1, "humidity": 34.0, "winddir": 139.0, "windspeed": 20.89, "windgust": 1.12, "maxdailygust": 8.05, "solarradiation": 264.61, "uv": 2.0, "rainrate": 0.0, "eventrain": 0.0, "hourlyrain": 0.0, "dailyrain": 0.0, "weeklyrain": 0.0, "monthlyrain": 2.177, "yearlyrain": 4.441, "lightning_num": 13.0, "lightning": 0.6, "lightning_time": "2022-04-20T17:17:17+00:00", "wh65batt": "OFF", "dewpoint": -4.7, "feelslike": 2.7, "heatindex": 12.3, "safe_exposure_time_skin_type_1": 83.3, "safe_exposure_time_skin_type_2": 100.0, "safe_exposure_time_skin_type_3": 133.3, "safe_exposure_time_skin_type_4": 166.7, "safe_exposure_time_skin_type_5": 266.7, "safe_exposure_time_skin_type_6": 433.3, "solarradiation_lux": 33494.9, "solarradiation_perceived": 90.0, "windchill": 2.7}',
     )
 
     # Test publishing raw data:

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -38,6 +38,7 @@ from ecowitt2mqtt.const import (
     STRIKES,
     TEMP_CELSIUS,
     TEMP_FAHRENHEIT,
+    TIME_MINUTES,
     TIME_SECONDS,
     UNIT_SYSTEM_IMPERIAL,
     UNIT_SYSTEM_METRIC,
@@ -277,6 +278,24 @@ def test_missing_distance(device_data, ecowitt, request):
             "solarradiation_perceived", 0.0, unit=PERCENTAGE
         ),
         "uv": CalculatedDataPoint("uv", 0, unit=UV_INDEX),
+        "safe_exposure_time_skin_type_1": CalculatedDataPoint(
+            "safe_exposure_time_skin_type_1", None, unit=TIME_MINUTES
+        ),
+        "safe_exposure_time_skin_type_2": CalculatedDataPoint(
+            "safe_exposure_time_skin_type_2", None, unit=TIME_MINUTES
+        ),
+        "safe_exposure_time_skin_type_3": CalculatedDataPoint(
+            "safe_exposure_time_skin_type_3", None, unit=TIME_MINUTES
+        ),
+        "safe_exposure_time_skin_type_4": CalculatedDataPoint(
+            "safe_exposure_time_skin_type_4", None, unit=TIME_MINUTES
+        ),
+        "safe_exposure_time_skin_type_5": CalculatedDataPoint(
+            "safe_exposure_time_skin_type_5", None, unit=TIME_MINUTES
+        ),
+        "safe_exposure_time_skin_type_6": CalculatedDataPoint(
+            "safe_exposure_time_skin_type_6", None, unit=TIME_MINUTES
+        ),
         "rrain_piezo": CalculatedDataPoint(
             "rrain", 0.000, unit=f"{RAINFALL_INCHES}/hr"
         ),
@@ -342,6 +361,24 @@ def test_missing_distance(device_data, ecowitt, request):
                     "solarradiation_perceived", 90.0, unit=PERCENTAGE
                 ),
                 "uv": CalculatedDataPoint("uv", 2.0, unit=UV_INDEX),
+                "safe_exposure_time_skin_type_1": CalculatedDataPoint(
+                    "safe_exposure_time_skin_type_1", 83.3, unit=TIME_MINUTES
+                ),
+                "safe_exposure_time_skin_type_2": CalculatedDataPoint(
+                    "safe_exposure_time_skin_type_2", 100.0, unit=TIME_MINUTES
+                ),
+                "safe_exposure_time_skin_type_3": CalculatedDataPoint(
+                    "safe_exposure_time_skin_type_3", 133.3, unit=TIME_MINUTES
+                ),
+                "safe_exposure_time_skin_type_4": CalculatedDataPoint(
+                    "safe_exposure_time_skin_type_4", 166.7, unit=TIME_MINUTES
+                ),
+                "safe_exposure_time_skin_type_5": CalculatedDataPoint(
+                    "safe_exposure_time_skin_type_5", 266.7, unit=TIME_MINUTES
+                ),
+                "safe_exposure_time_skin_type_6": CalculatedDataPoint(
+                    "safe_exposure_time_skin_type_6", 433.3, unit=TIME_MINUTES
+                ),
                 "rainrate": CalculatedDataPoint(
                     "rainrate", 0.0, unit=f"{RAINFALL_INCHES}/hr"
                 ),
@@ -399,6 +436,24 @@ def test_missing_distance(device_data, ecowitt, request):
                     "solarradiation_perceived", 70.0, unit=PERCENTAGE
                 ),
                 "uv": CalculatedDataPoint("uv", 0, unit=UV_INDEX),
+                "safe_exposure_time_skin_type_1": CalculatedDataPoint(
+                    "safe_exposure_time_skin_type_1", None, unit=TIME_MINUTES
+                ),
+                "safe_exposure_time_skin_type_2": CalculatedDataPoint(
+                    "safe_exposure_time_skin_type_2", None, unit=TIME_MINUTES
+                ),
+                "safe_exposure_time_skin_type_3": CalculatedDataPoint(
+                    "safe_exposure_time_skin_type_3", None, unit=TIME_MINUTES
+                ),
+                "safe_exposure_time_skin_type_4": CalculatedDataPoint(
+                    "safe_exposure_time_skin_type_4", None, unit=TIME_MINUTES
+                ),
+                "safe_exposure_time_skin_type_5": CalculatedDataPoint(
+                    "safe_exposure_time_skin_type_5", None, unit=TIME_MINUTES
+                ),
+                "safe_exposure_time_skin_type_6": CalculatedDataPoint(
+                    "safe_exposure_time_skin_type_6", None, unit=TIME_MINUTES
+                ),
                 "rainrate": CalculatedDataPoint(
                     "rainrate", 0.000, unit=f"{RAINFALL_INCHES}/hr"
                 ),
@@ -524,6 +579,24 @@ def test_missing_distance(device_data, ecowitt, request):
                     "solarradiation_perceived", 0.0, unit=PERCENTAGE
                 ),
                 "uv": CalculatedDataPoint("uv", 0, unit=UV_INDEX),
+                "safe_exposure_time_skin_type_1": CalculatedDataPoint(
+                    "safe_exposure_time_skin_type_1", None, unit=TIME_MINUTES
+                ),
+                "safe_exposure_time_skin_type_2": CalculatedDataPoint(
+                    "safe_exposure_time_skin_type_2", None, unit=TIME_MINUTES
+                ),
+                "safe_exposure_time_skin_type_3": CalculatedDataPoint(
+                    "safe_exposure_time_skin_type_3", None, unit=TIME_MINUTES
+                ),
+                "safe_exposure_time_skin_type_4": CalculatedDataPoint(
+                    "safe_exposure_time_skin_type_4", None, unit=TIME_MINUTES
+                ),
+                "safe_exposure_time_skin_type_5": CalculatedDataPoint(
+                    "safe_exposure_time_skin_type_5", None, unit=TIME_MINUTES
+                ),
+                "safe_exposure_time_skin_type_6": CalculatedDataPoint(
+                    "safe_exposure_time_skin_type_6", None, unit=TIME_MINUTES
+                ),
                 "rrain_piezo": CalculatedDataPoint(
                     "rrain", 0.000, unit=f"{RAINFALL_INCHES}/hr"
                 ),
@@ -601,6 +674,24 @@ def test_missing_distance(device_data, ecowitt, request):
                     "solarradiation_perceived", 0.0, unit=PERCENTAGE
                 ),
                 "uv": CalculatedDataPoint("uv", 0, unit=UV_INDEX),
+                "safe_exposure_time_skin_type_1": CalculatedDataPoint(
+                    "safe_exposure_time_skin_type_1", None, unit=TIME_MINUTES
+                ),
+                "safe_exposure_time_skin_type_2": CalculatedDataPoint(
+                    "safe_exposure_time_skin_type_2", None, unit=TIME_MINUTES
+                ),
+                "safe_exposure_time_skin_type_3": CalculatedDataPoint(
+                    "safe_exposure_time_skin_type_3", None, unit=TIME_MINUTES
+                ),
+                "safe_exposure_time_skin_type_4": CalculatedDataPoint(
+                    "safe_exposure_time_skin_type_4", None, unit=TIME_MINUTES
+                ),
+                "safe_exposure_time_skin_type_5": CalculatedDataPoint(
+                    "safe_exposure_time_skin_type_5", None, unit=TIME_MINUTES
+                ),
+                "safe_exposure_time_skin_type_6": CalculatedDataPoint(
+                    "safe_exposure_time_skin_type_6", None, unit=TIME_MINUTES
+                ),
                 "rainrate": CalculatedDataPoint(
                     "rainrate", 0.000, unit=f"{RAINFALL_INCHES}/hr"
                 ),
@@ -759,6 +850,24 @@ def test_missing_distance(device_data, ecowitt, request):
                     "solarradiation_perceived", 87.0, unit=PERCENTAGE
                 ),
                 "uv": CalculatedDataPoint("uv", 1, unit=UV_INDEX),
+                "safe_exposure_time_skin_type_1": CalculatedDataPoint(
+                    "safe_exposure_time_skin_type_1", 166.7, unit=TIME_MINUTES
+                ),
+                "safe_exposure_time_skin_type_2": CalculatedDataPoint(
+                    "safe_exposure_time_skin_type_2", 200.0, unit=TIME_MINUTES
+                ),
+                "safe_exposure_time_skin_type_3": CalculatedDataPoint(
+                    "safe_exposure_time_skin_type_3", 266.7, unit=TIME_MINUTES
+                ),
+                "safe_exposure_time_skin_type_4": CalculatedDataPoint(
+                    "safe_exposure_time_skin_type_4", 333.3, unit=TIME_MINUTES
+                ),
+                "safe_exposure_time_skin_type_5": CalculatedDataPoint(
+                    "safe_exposure_time_skin_type_5", 533.3, unit=TIME_MINUTES
+                ),
+                "safe_exposure_time_skin_type_6": CalculatedDataPoint(
+                    "safe_exposure_time_skin_type_6", 866.7, unit=TIME_MINUTES
+                ),
                 "temp1": CalculatedDataPoint("temp", 66.4, unit=TEMP_FAHRENHEIT),
                 "humidity1": CalculatedDataPoint("humidity", 69, unit=PERCENTAGE),
                 "soilmoisture1": CalculatedDataPoint("moisture", 22, unit=PERCENTAGE),
@@ -817,6 +926,24 @@ def test_missing_distance(device_data, ecowitt, request):
                     "solarradiation_perceived", 98.0, unit=PERCENTAGE
                 ),
                 "uv": CalculatedDataPoint("uv", 6, unit=UV_INDEX),
+                "safe_exposure_time_skin_type_1": CalculatedDataPoint(
+                    "safe_exposure_time_skin_type_1", 27.8, unit=TIME_MINUTES
+                ),
+                "safe_exposure_time_skin_type_2": CalculatedDataPoint(
+                    "safe_exposure_time_skin_type_2", 33.3, unit=TIME_MINUTES
+                ),
+                "safe_exposure_time_skin_type_3": CalculatedDataPoint(
+                    "safe_exposure_time_skin_type_3", 44.4, unit=TIME_MINUTES
+                ),
+                "safe_exposure_time_skin_type_4": CalculatedDataPoint(
+                    "safe_exposure_time_skin_type_4", 55.6, unit=TIME_MINUTES
+                ),
+                "safe_exposure_time_skin_type_5": CalculatedDataPoint(
+                    "safe_exposure_time_skin_type_5", 88.9, unit=TIME_MINUTES
+                ),
+                "safe_exposure_time_skin_type_6": CalculatedDataPoint(
+                    "safe_exposure_time_skin_type_6", 144.4, unit=TIME_MINUTES
+                ),
                 "rainrate": CalculatedDataPoint(
                     "rainrate", 0.000, unit=f"{RAINFALL_INCHES}/hr"
                 ),
@@ -883,6 +1010,24 @@ def test_missing_distance(device_data, ecowitt, request):
                     "solarradiation_perceived", 0.0, unit=PERCENTAGE
                 ),
                 "uv": CalculatedDataPoint("uv", 0, unit=UV_INDEX),
+                "safe_exposure_time_skin_type_1": CalculatedDataPoint(
+                    "safe_exposure_time_skin_type_1", None, unit=TIME_MINUTES
+                ),
+                "safe_exposure_time_skin_type_2": CalculatedDataPoint(
+                    "safe_exposure_time_skin_type_2", None, unit=TIME_MINUTES
+                ),
+                "safe_exposure_time_skin_type_3": CalculatedDataPoint(
+                    "safe_exposure_time_skin_type_3", None, unit=TIME_MINUTES
+                ),
+                "safe_exposure_time_skin_type_4": CalculatedDataPoint(
+                    "safe_exposure_time_skin_type_4", None, unit=TIME_MINUTES
+                ),
+                "safe_exposure_time_skin_type_5": CalculatedDataPoint(
+                    "safe_exposure_time_skin_type_5", None, unit=TIME_MINUTES
+                ),
+                "safe_exposure_time_skin_type_6": CalculatedDataPoint(
+                    "safe_exposure_time_skin_type_6", None, unit=TIME_MINUTES
+                ),
                 "wh65batt": CalculatedDataPoint("batt", BooleanBatteryState.OFF),
                 "dewpoint": CalculatedDataPoint("dewpoint", 53.4, unit=TEMP_FAHRENHEIT),
                 "feelslike": CalculatedDataPoint(
@@ -951,7 +1096,25 @@ def test_unit_conversion_to_imperial(device_data, ecowitt):
         "solarradiation_perceived": CalculatedDataPoint(
             "solarradiation_perceived", 90.0, unit=PERCENTAGE
         ),
-        "uv": CalculatedDataPoint("uv", 2, unit=UV_INDEX),
+        "uv": CalculatedDataPoint("uv", 2.0, unit=UV_INDEX),
+        "safe_exposure_time_skin_type_1": CalculatedDataPoint(
+            "safe_exposure_time_skin_type_1", 83.3, unit=TIME_MINUTES
+        ),
+        "safe_exposure_time_skin_type_2": CalculatedDataPoint(
+            "safe_exposure_time_skin_type_2", 100.0, unit=TIME_MINUTES
+        ),
+        "safe_exposure_time_skin_type_3": CalculatedDataPoint(
+            "safe_exposure_time_skin_type_3", 133.3, unit=TIME_MINUTES
+        ),
+        "safe_exposure_time_skin_type_4": CalculatedDataPoint(
+            "safe_exposure_time_skin_type_4", 166.7, unit=TIME_MINUTES
+        ),
+        "safe_exposure_time_skin_type_5": CalculatedDataPoint(
+            "safe_exposure_time_skin_type_5", 266.7, unit=TIME_MINUTES
+        ),
+        "safe_exposure_time_skin_type_6": CalculatedDataPoint(
+            "safe_exposure_time_skin_type_6", 433.3, unit=TIME_MINUTES
+        ),
         "rainrate": CalculatedDataPoint(
             "rainrate", 0.000, unit=f"{RAINFALL_INCHES}/hr"
         ),
@@ -1022,7 +1185,25 @@ def test_unit_conversion_to_metric(device_data, ecowitt):
         "solarradiation_perceived": CalculatedDataPoint(
             "solarradiation_perceived", 90.0, unit=PERCENTAGE
         ),
-        "uv": CalculatedDataPoint("uv", 2, unit=UV_INDEX),
+        "uv": CalculatedDataPoint("uv", 2.0, unit=UV_INDEX),
+        "safe_exposure_time_skin_type_1": CalculatedDataPoint(
+            "safe_exposure_time_skin_type_1", 83.3, unit=TIME_MINUTES
+        ),
+        "safe_exposure_time_skin_type_2": CalculatedDataPoint(
+            "safe_exposure_time_skin_type_2", 100.0, unit=TIME_MINUTES
+        ),
+        "safe_exposure_time_skin_type_3": CalculatedDataPoint(
+            "safe_exposure_time_skin_type_3", 133.3, unit=TIME_MINUTES
+        ),
+        "safe_exposure_time_skin_type_4": CalculatedDataPoint(
+            "safe_exposure_time_skin_type_4", 166.7, unit=TIME_MINUTES
+        ),
+        "safe_exposure_time_skin_type_5": CalculatedDataPoint(
+            "safe_exposure_time_skin_type_5", 266.7, unit=TIME_MINUTES
+        ),
+        "safe_exposure_time_skin_type_6": CalculatedDataPoint(
+            "safe_exposure_time_skin_type_6", 433.3, unit=TIME_MINUTES
+        ),
         "rainrate": CalculatedDataPoint(
             "rainrate", 0.0, unit=f"{RAINFALL_MILLIMETERS}/hr"
         ),
@@ -1071,6 +1252,24 @@ def test_nonnumeric_value(device_data, ecowitt):
             "solarradiation_perceived", 90.0, unit=PERCENTAGE
         ),
         "uv": CalculatedDataPoint("uv", 2.0, unit=UV_INDEX),
+        "safe_exposure_time_skin_type_1": CalculatedDataPoint(
+            "safe_exposure_time_skin_type_1", 83.3, unit=TIME_MINUTES
+        ),
+        "safe_exposure_time_skin_type_2": CalculatedDataPoint(
+            "safe_exposure_time_skin_type_2", 100.0, unit=TIME_MINUTES
+        ),
+        "safe_exposure_time_skin_type_3": CalculatedDataPoint(
+            "safe_exposure_time_skin_type_3", 133.3, unit=TIME_MINUTES
+        ),
+        "safe_exposure_time_skin_type_4": CalculatedDataPoint(
+            "safe_exposure_time_skin_type_4", 166.7, unit=TIME_MINUTES
+        ),
+        "safe_exposure_time_skin_type_5": CalculatedDataPoint(
+            "safe_exposure_time_skin_type_5", 266.7, unit=TIME_MINUTES
+        ),
+        "safe_exposure_time_skin_type_6": CalculatedDataPoint(
+            "safe_exposure_time_skin_type_6", 433.3, unit=TIME_MINUTES
+        ),
         "rainrate": CalculatedDataPoint("rainrate", 0.0, unit=f"{RAINFALL_INCHES}/hr"),
         "eventrain": CalculatedDataPoint("rain", 0.0, unit=RAINFALL_INCHES),
         "hourlyrain": CalculatedDataPoint("rain", 0.0, unit=RAINFALL_INCHES),
@@ -1140,6 +1339,24 @@ def test_unknown_battery(device_data, ecowitt):
             "solarradiation_perceived", 90.0, unit=PERCENTAGE
         ),
         "uv": CalculatedDataPoint("uv", 2.0, unit=UV_INDEX),
+        "safe_exposure_time_skin_type_1": CalculatedDataPoint(
+            "safe_exposure_time_skin_type_1", 83.3, unit=TIME_MINUTES
+        ),
+        "safe_exposure_time_skin_type_2": CalculatedDataPoint(
+            "safe_exposure_time_skin_type_2", 100.0, unit=TIME_MINUTES
+        ),
+        "safe_exposure_time_skin_type_3": CalculatedDataPoint(
+            "safe_exposure_time_skin_type_3", 133.3, unit=TIME_MINUTES
+        ),
+        "safe_exposure_time_skin_type_4": CalculatedDataPoint(
+            "safe_exposure_time_skin_type_4", 166.7, unit=TIME_MINUTES
+        ),
+        "safe_exposure_time_skin_type_5": CalculatedDataPoint(
+            "safe_exposure_time_skin_type_5", 266.7, unit=TIME_MINUTES
+        ),
+        "safe_exposure_time_skin_type_6": CalculatedDataPoint(
+            "safe_exposure_time_skin_type_6", 433.3, unit=TIME_MINUTES
+        ),
         "rainrate": CalculatedDataPoint("rainrate", 0.0, unit=f"{RAINFALL_INCHES}/hr"),
         "eventrain": CalculatedDataPoint("rain", 0.0, unit=RAINFALL_INCHES),
         "hourlyrain": CalculatedDataPoint("rain", 0.0, unit=RAINFALL_INCHES),


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds calculated sensors for safe sun exposure time (in minutes) based on the currently-detected UV index (if it exists). The values are calculated from https://www.openuv.io/kb/skin-types-safe-exposure-time-calculation.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
