### PR TITLE
Pass data to calculators as args (instead of kwargs)

### DIFF
--- a/ecowitt2mqtt/data.py
+++ b/ecowitt2mqtt/data.py
@@ -153,7 +153,9 @@ UNIT_SUFFIX_MAP = {
     DATA_POINT_TOTAL_AIN: "in",
 }
 
-# Map calculated data points to the data points they depend on:
+# Map calculated data points to the data points they depend on - note that the order
+# of the input keys inside the tuple is important, as those values are passed to their
+# respective calculator (as args) in that order:
 DEW_POINT_KEYS = (DATA_POINT_TEMPF, DATA_POINT_HUMIDITY)
 FEELS_LIKE_KEYS = (DATA_POINT_TEMPF, DATA_POINT_HUMIDITY, DATA_POINT_WINDSPEEDMPH)
 HEAT_INDEX_KEYS = (DATA_POINT_TEMPF, DATA_POINT_HUMIDITY)
@@ -254,15 +256,6 @@ class ProcessedData:
                 continue
 
             if calculator := get_calculator_function(self.ecowitt, payload_key):
-                if len(input_keys) == 1:
-                    # If we only have one input key/value, generalize its kwarg name so
-                    # that its calculator can be used across multiple data points more
-                    # easily:
-                    kwargs = {"value": get_typed_value(self.data[input_keys[0]])}
-                else:
-                    kwargs = {
-                        remove_unit_from_key(key): get_typed_value(self.data[key])
-                        for key in input_keys
-                    }
-
-                self.output[payload_key] = calculator(**kwargs)
+                self.output[payload_key] = calculator(
+                    *(get_typed_value(self.data[key]) for key in input_keys)
+                )

--- a/ecowitt2mqtt/helpers/calculator/battery.py
+++ b/ecowitt2mqtt/helpers/calculator/battery.py
@@ -67,7 +67,7 @@ BATTERY_STRATEGY_MAP = {
 
 
 def calculate_battery(
-    ecowitt: Ecowitt, payload_key: str, data_point_key: str, *, value: float
+    ecowitt: Ecowitt, payload_key: str, data_point_key: str, value: float
 ) -> CalculatedDataPoint:
     """Calculate a battery value."""
     strategy = get_battery_strategy(ecowitt, payload_key)

--- a/ecowitt2mqtt/helpers/calculator/leak.py
+++ b/ecowitt2mqtt/helpers/calculator/leak.py
@@ -18,7 +18,7 @@ class LeakState(StrEnum):
 
 
 def calculate_leak(
-    ecowitt: Ecowitt, payload_key: str, data_point_key: str, *, value: float
+    ecowitt: Ecowitt, payload_key: str, data_point_key: str, value: float
 ) -> CalculatedDataPoint:
     """Calculate a boolean leak state."""
     if value == 0.0:

--- a/ecowitt2mqtt/helpers/calculator/meteo.py
+++ b/ecowitt2mqtt/helpers/calculator/meteo.py
@@ -89,7 +89,7 @@ def _get_temperature_object(
 
 
 def calculate_co2(
-    ecowitt: Ecowitt, payload_key: str, data_point_key: str, *, value: float
+    ecowitt: Ecowitt, payload_key: str, data_point_key: str, value: float
 ) -> CalculatedDataPoint:
     """Calculate CO2."""
     return CalculatedDataPoint(
@@ -101,7 +101,6 @@ def calculate_dew_point(
     ecowitt: Ecowitt,
     payload_key: str,
     data_point_key: str,
-    *,
     temp: float,
     humidity: float,
 ) -> CalculatedDataPoint:
@@ -124,7 +123,6 @@ def calculate_feels_like(
     ecowitt: Ecowitt,
     payload_key: str,
     data_point_key: str,
-    *,
     temp: float,
     humidity: float,
     windspeed: float,
@@ -148,7 +146,6 @@ def calculate_heat_index(
     ecowitt: Ecowitt,
     payload_key: str,
     data_point_key: str,
-    *,
     temp: float,
     humidity: float,
 ) -> CalculatedDataPoint:
@@ -168,7 +165,7 @@ def calculate_heat_index(
 
 
 def calculate_lightning_strike_distance(
-    ecowitt: Ecowitt, payload_key: str, data_point_key: str, *, value: float
+    ecowitt: Ecowitt, payload_key: str, data_point_key: str, value: float
 ) -> CalculatedDataPoint:
     """Calculate lightning strike distance in the appropriate unit system.
 
@@ -186,14 +183,14 @@ def calculate_lightning_strike_distance(
 
 
 def calculate_lightning_strikes(
-    ecowitt: Ecowitt, payload_key: str, data_point_key: str, *, value: float
+    ecowitt: Ecowitt, payload_key: str, data_point_key: str, value: float
 ) -> CalculatedDataPoint:
     """Calculate lightning strikes."""
     return CalculatedDataPoint(data_point_key=data_point_key, value=value, unit=STRIKES)
 
 
 def calculate_moisture(
-    ecowitt: Ecowitt, payload_key: str, data_point_key: str, *, value: float
+    ecowitt: Ecowitt, payload_key: str, data_point_key: str, value: float
 ) -> CalculatedDataPoint:
     """Calculate moisture."""
     return CalculatedDataPoint(
@@ -202,7 +199,7 @@ def calculate_moisture(
 
 
 def calculate_pm25(
-    ecowitt: Ecowitt, payload_key: str, data_point_key: str, *, value: float
+    ecowitt: Ecowitt, payload_key: str, data_point_key: str, value: float
 ) -> CalculatedDataPoint:
     """Calculate PM2.5 pollution."""
     return CalculatedDataPoint(
@@ -213,7 +210,7 @@ def calculate_pm25(
 
 
 def calculate_pm10(
-    ecowitt: Ecowitt, payload_key: str, data_point_key: str, *, value: float
+    ecowitt: Ecowitt, payload_key: str, data_point_key: str, value: float
 ) -> CalculatedDataPoint:
     """Calculate PM10.0 pollution."""
     return CalculatedDataPoint(
@@ -224,7 +221,7 @@ def calculate_pm10(
 
 
 def calculate_pressure(
-    ecowitt: Ecowitt, payload_key: str, data_point_key: str, *, value: float
+    ecowitt: Ecowitt, payload_key: str, data_point_key: str, value: float
 ) -> CalculatedDataPoint:
     """Calculate pressure in the appropriate unit system."""
     if ecowitt.config.input_unit_system == ecowitt.config.output_unit_system:
@@ -241,7 +238,7 @@ def calculate_pressure(
 
 
 def calculate_rain_rate(
-    ecowitt: Ecowitt, payload_key: str, data_point_key: str, *, value: float
+    ecowitt: Ecowitt, payload_key: str, data_point_key: str, value: float
 ) -> CalculatedDataPoint:
     """Calculate rain rate in the appropriate unit system."""
     data_point = calculate_rain_volume(
@@ -252,7 +249,7 @@ def calculate_rain_rate(
 
 
 def calculate_rain_volume(
-    ecowitt: Ecowitt, payload_key: str, data_point_key: str, *, value: float
+    ecowitt: Ecowitt, payload_key: str, data_point_key: str, value: float
 ) -> CalculatedDataPoint:
     """Calculate rain volume in the appropriate unit system."""
     if ecowitt.config.input_unit_system == ecowitt.config.output_unit_system:
@@ -269,7 +266,7 @@ def calculate_rain_volume(
 
 
 def calculate_relative_humidity(
-    ecowitt: Ecowitt, payload_key: str, data_point_key: str, *, value: float
+    ecowitt: Ecowitt, payload_key: str, data_point_key: str, value: float
 ) -> CalculatedDataPoint:
     """Calculate humidity."""
     return CalculatedDataPoint(
@@ -278,7 +275,7 @@ def calculate_relative_humidity(
 
 
 def calculate_safe_exposure_time(
-    ecowitt: Ecowitt, payload_key: str, data_point_key: str, *, value: float
+    ecowitt: Ecowitt, payload_key: str, data_point_key: str, value: float
 ) -> CalculatedDataPoint:
     """Calculate the number of minutes one can be safely exposed to a UV index."""
     try:
@@ -293,7 +290,7 @@ def calculate_safe_exposure_time(
 
 
 def calculate_solar_radiation_lux(
-    ecowitt: Ecowitt, payload_key: str, data_point_key: str, *, value: float
+    ecowitt: Ecowitt, payload_key: str, data_point_key: str, value: float
 ) -> CalculatedDataPoint:
     """Calculate solar radiation (lux)."""
     return CalculatedDataPoint(
@@ -304,7 +301,7 @@ def calculate_solar_radiation_lux(
 
 
 def calculate_solar_radiation_perceived(
-    ecowitt: Ecowitt, payload_key: str, data_point_key: str, *, value: float
+    ecowitt: Ecowitt, payload_key: str, data_point_key: str, value: float
 ) -> CalculatedDataPoint:
     """Calculate solar radiation (% perceived)."""
     lux_data_point = calculate_solar_radiation_lux(
@@ -325,7 +322,7 @@ def calculate_solar_radiation_perceived(
 
 
 def calculate_solar_radiation_wm2(
-    ecowitt: Ecowitt, payload_key: str, data_point_key: str, *, value: float
+    ecowitt: Ecowitt, payload_key: str, data_point_key: str, value: float
 ) -> CalculatedDataPoint:
     """Calculate solar radiation (W/m²)."""
     return CalculatedDataPoint(
@@ -336,7 +333,7 @@ def calculate_solar_radiation_wm2(
 
 
 def calculate_temperature(
-    ecowitt: Ecowitt, payload_key: str, data_point_key: str, *, value: float
+    ecowitt: Ecowitt, payload_key: str, data_point_key: str, value: float
 ) -> CalculatedDataPoint:
     """Calculate temperature in the appropriate unit system."""
     temp_obj = _get_temperature_object(value, ecowitt.config.input_unit_system)
@@ -353,7 +350,7 @@ def calculate_temperature(
 
 
 def calculate_uv_index(
-    ecowitt: Ecowitt, payload_key: str, data_point_key: str, *, value: float
+    ecowitt: Ecowitt, payload_key: str, data_point_key: str, value: float
 ) -> CalculatedDataPoint:
     """Calculate UV index."""
     return CalculatedDataPoint(
@@ -365,7 +362,6 @@ def calculate_wind_chill(
     ecowitt: Ecowitt,
     payload_key: str,
     data_point_key: str,
-    *,
     temp: float,
     windspeed: float,
 ) -> CalculatedDataPoint:
@@ -394,14 +390,14 @@ def calculate_wind_chill(
 
 
 def calculate_wind_dir(
-    ecowitt: Ecowitt, payload_key: str, data_point_key: str, *, value: float
+    ecowitt: Ecowitt, payload_key: str, data_point_key: str, value: float
 ) -> CalculatedDataPoint:
     """Calculate wind direction."""
     return CalculatedDataPoint(data_point_key=data_point_key, value=value, unit=DEGREE)
 
 
 def calculate_wind_speed(
-    ecowitt: Ecowitt, payload_key: str, data_point_key: str, *, value: float
+    ecowitt: Ecowitt, payload_key: str, data_point_key: str, value: float
 ) -> CalculatedDataPoint:
     """Calculate wind speed in the appropriate unit system."""
     if ecowitt.config.input_unit_system == ecowitt.config.output_unit_system:

--- a/ecowitt2mqtt/helpers/calculator/time.py
+++ b/ecowitt2mqtt/helpers/calculator/time.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 
 
 def calculate_dt_from_epoch(
-    ecowitt: Ecowitt, payload_key: str, data_point_key: str, *, value: float | str
+    ecowitt: Ecowitt, payload_key: str, data_point_key: str, value: float | str
 ) -> CalculatedDataPoint:
     """Calculate a datetime from an epoch."""
     try:
@@ -27,7 +27,7 @@ def calculate_dt_from_epoch(
 
 
 def calculate_runtime(
-    ecowitt: Ecowitt, payload_key: str, data_point_key: str, *, value: float
+    ecowitt: Ecowitt, payload_key: str, data_point_key: str, value: float
 ) -> CalculatedDataPoint:
     """Calculate a datetime from an epoch."""
     return CalculatedDataPoint(


### PR DESCRIPTION
**Describe what the PR does:**

#212 didn't go quite far enough to address the issue of calculator reuse with different input keys. This PR adjusts calculators in general to accept their input data as args (instead of kwargs) so that they can be more easily used across data points with different names.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
