### PR TITLE
Fix incorrect HASS MQTT Discovery topic for certain sensors

### DIFF
--- a/ecowitt2mqtt/helpers/calculator/__init__.py
+++ b/ecowitt2mqtt/helpers/calculator/__init__.py
@@ -2,8 +2,16 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import Enum
 
 from ecowitt2mqtt.helpers.typing import DataValueType
+
+
+class DataPointType(Enum):
+    """Define types of battery configuration."""
+
+    BOOLEAN = 1
+    NON_BOOLEAN = 2
 
 
 @dataclass
@@ -13,3 +21,4 @@ class CalculatedDataPoint:
     data_point_key: str
     value: DataValueType
     unit: str | None = None
+    data_type: DataPointType = DataPointType.NON_BOOLEAN

--- a/ecowitt2mqtt/helpers/calculator/battery.py
+++ b/ecowitt2mqtt/helpers/calculator/battery.py
@@ -24,7 +24,7 @@ from ecowitt2mqtt.const import (
     ELECTRIC_POTENTIAL_VOLT,
     PERCENTAGE,
 )
-from ecowitt2mqtt.helpers.calculator import CalculatedDataPoint
+from ecowitt2mqtt.helpers.calculator import CalculatedDataPoint, DataPointType
 from ecowitt2mqtt.util import glob_search
 
 if TYPE_CHECKING:
@@ -89,10 +89,14 @@ def calculate_battery(
         )
     if value == 0.0:
         return CalculatedDataPoint(
-            data_point_key=data_point_key, value=BooleanBatteryState.OFF
+            data_point_key=data_point_key,
+            value=BooleanBatteryState.OFF,
+            data_type=DataPointType.BOOLEAN,
         )
     return CalculatedDataPoint(
-        data_point_key=data_point_key, value=BooleanBatteryState.ON
+        data_point_key=data_point_key,
+        value=BooleanBatteryState.ON,
+        data_type=DataPointType.BOOLEAN,
     )
 
 

--- a/ecowitt2mqtt/helpers/calculator/leak.py
+++ b/ecowitt2mqtt/helpers/calculator/leak.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ecowitt2mqtt.backports.enum import StrEnum
-from ecowitt2mqtt.helpers.calculator import CalculatedDataPoint
+from ecowitt2mqtt.helpers.calculator import CalculatedDataPoint, DataPointType
 
 if TYPE_CHECKING:
     from ecowitt2mqtt.core import Ecowitt
@@ -22,5 +22,13 @@ def calculate_leak(
 ) -> CalculatedDataPoint:
     """Calculate a boolean leak state."""
     if value == 0.0:
-        return CalculatedDataPoint(data_point_key=data_point_key, value=LeakState.OFF)
-    return CalculatedDataPoint(data_point_key=data_point_key, value=LeakState.ON)
+        return CalculatedDataPoint(
+            data_point_key=data_point_key,
+            value=LeakState.OFF,
+            data_type=DataPointType.BOOLEAN,
+        )
+    return CalculatedDataPoint(
+        data_point_key=data_point_key,
+        value=LeakState.ON,
+        data_type=DataPointType.BOOLEAN,
+    )

--- a/tests/publisher/test_hass_discovery.py
+++ b/tests/publisher/test_hass_discovery.py
@@ -1074,15 +1074,15 @@ async def test_publish(config, device_data, ecowitt, request, setup_asyncio_mqtt
                 b"44.3",
             ),
             call(
-                "homeassistant/binary_sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/frostrisk/config",
-                b'{"availability_topic": "homeassistant/binary_sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/frostrisk/availability", "device": {"identifiers": ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"], "manufacturer": "Ecowitt", "model": "GW2000A", "name": "GW2000A", "sw_version": "GW2000A_V2.1.4"}, "name": "frostrisk", "qos": 1, "state_topic": "homeassistant/binary_sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/frostrisk/state", "unique_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_frostrisk", "icon": "mdi:snowflake-alert", "state_class": "measurement"}',
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/frostrisk/config",
+                b'{"availability_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/frostrisk/availability", "device": {"identifiers": ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"], "manufacturer": "Ecowitt", "model": "GW2000A", "name": "GW2000A", "sw_version": "GW2000A_V2.1.4"}, "name": "frostrisk", "qos": 1, "state_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/frostrisk/state", "unique_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_frostrisk", "icon": "mdi:snowflake-alert", "state_class": "measurement"}',
             ),
             call(
-                "homeassistant/binary_sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/frostrisk/availability",
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/frostrisk/availability",
                 b"online",
             ),
             call(
-                "homeassistant/binary_sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/frostrisk/state",
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/frostrisk/state",
                 b"No risk",
             ),
             call(
@@ -1242,15 +1242,15 @@ async def test_publish(config, device_data, ecowitt, request, setup_asyncio_mqtt
                 b"0.0",
             ),
             call(
-                "homeassistant/binary_sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/thermalperception/config",
-                b'{"availability_topic": "homeassistant/binary_sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/thermalperception/availability", "device": {"identifiers": ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"], "manufacturer": "Ecowitt", "model": "GW2000A", "name": "GW2000A", "sw_version": "GW2000A_V2.1.4"}, "name": "thermalperception", "qos": 1, "state_topic": "homeassistant/binary_sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/thermalperception/state", "unique_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_thermalperception", "icon": "mdi:account", "state_class": "measurement"}',
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/thermalperception/config",
+                b'{"availability_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/thermalperception/availability", "device": {"identifiers": ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"], "manufacturer": "Ecowitt", "model": "GW2000A", "name": "GW2000A", "sw_version": "GW2000A_V2.1.4"}, "name": "thermalperception", "qos": 1, "state_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/thermalperception/state", "unique_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_thermalperception", "icon": "mdi:water", "state_class": "measurement"}',
             ),
             call(
-                "homeassistant/binary_sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/thermalperception/availability",
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/thermalperception/availability",
                 b"online",
             ),
             call(
-                "homeassistant/binary_sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/thermalperception/state",
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/thermalperception/state",
                 b"Dry",
             ),
             call(
@@ -2294,15 +2294,15 @@ async def test_publish_custom_entity_id_prefix(
                 b"44.3",
             ),
             call(
-                "homeassistant/binary_sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/frostrisk/config",
-                b'{"availability_topic": "homeassistant/binary_sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/frostrisk/availability", "device": {"identifiers": ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"], "manufacturer": "Ecowitt", "model": "GW2000A", "name": "GW2000A", "sw_version": "GW2000A_V2.1.4"}, "name": "test_prefix_frostrisk", "qos": 1, "state_topic": "homeassistant/binary_sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/frostrisk/state", "unique_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_frostrisk", "icon": "mdi:snowflake-alert", "state_class": "measurement"}',
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/frostrisk/config",
+                b'{"availability_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/frostrisk/availability", "device": {"identifiers": ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"], "manufacturer": "Ecowitt", "model": "GW2000A", "name": "GW2000A", "sw_version": "GW2000A_V2.1.4"}, "name": "test_prefix_frostrisk", "qos": 1, "state_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/frostrisk/state", "unique_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_frostrisk", "icon": "mdi:snowflake-alert", "state_class": "measurement"}',
             ),
             call(
-                "homeassistant/binary_sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/frostrisk/availability",
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/frostrisk/availability",
                 b"online",
             ),
             call(
-                "homeassistant/binary_sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/frostrisk/state",
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/frostrisk/state",
                 b"No risk",
             ),
             call(
@@ -2462,15 +2462,15 @@ async def test_publish_custom_entity_id_prefix(
                 b"0.0",
             ),
             call(
-                "homeassistant/binary_sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/thermalperception/config",
-                b'{"availability_topic": "homeassistant/binary_sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/thermalperception/availability", "device": {"identifiers": ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"], "manufacturer": "Ecowitt", "model": "GW2000A", "name": "GW2000A", "sw_version": "GW2000A_V2.1.4"}, "name": "test_prefix_thermalperception", "qos": 1, "state_topic": "homeassistant/binary_sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/thermalperception/state", "unique_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_thermalperception", "icon": "mdi:account", "state_class": "measurement"}',
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/thermalperception/config",
+                b'{"availability_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/thermalperception/availability", "device": {"identifiers": ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"], "manufacturer": "Ecowitt", "model": "GW2000A", "name": "GW2000A", "sw_version": "GW2000A_V2.1.4"}, "name": "test_prefix_thermalperception", "qos": 1, "state_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/thermalperception/state", "unique_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_thermalperception", "icon": "mdi:water", "state_class": "measurement"}',
             ),
             call(
-                "homeassistant/binary_sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/thermalperception/availability",
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/thermalperception/availability",
                 b"online",
             ),
             call(
-                "homeassistant/binary_sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/thermalperception/state",
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/thermalperception/state",
                 b"Dry",
             ),
             call(
@@ -3513,15 +3513,15 @@ async def test_publish_numeric_battery_strategy(
                 b"44.3",
             ),
             call(
-                "homeassistant/binary_sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/frostrisk/config",
-                b'{"availability_topic": "homeassistant/binary_sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/frostrisk/availability", "device": {"identifiers": ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"], "manufacturer": "Ecowitt", "model": "GW2000A", "name": "GW2000A", "sw_version": "GW2000A_V2.1.4"}, "name": "frostrisk", "qos": 1, "state_topic": "homeassistant/binary_sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/frostrisk/state", "unique_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_frostrisk", "icon": "mdi:snowflake-alert", "state_class": "measurement"}',
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/frostrisk/config",
+                b'{"availability_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/frostrisk/availability", "device": {"identifiers": ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"], "manufacturer": "Ecowitt", "model": "GW2000A", "name": "GW2000A", "sw_version": "GW2000A_V2.1.4"}, "name": "frostrisk", "qos": 1, "state_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/frostrisk/state", "unique_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_frostrisk", "icon": "mdi:snowflake-alert", "state_class": "measurement"}',
             ),
             call(
-                "homeassistant/binary_sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/frostrisk/availability",
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/frostrisk/availability",
                 b"online",
             ),
             call(
-                "homeassistant/binary_sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/frostrisk/state",
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/frostrisk/state",
                 b"No risk",
             ),
             call(
@@ -3681,15 +3681,15 @@ async def test_publish_numeric_battery_strategy(
                 b"0.0",
             ),
             call(
-                "homeassistant/binary_sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/thermalperception/config",
-                b'{"availability_topic": "homeassistant/binary_sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/thermalperception/availability", "device": {"identifiers": ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"], "manufacturer": "Ecowitt", "model": "GW2000A", "name": "GW2000A", "sw_version": "GW2000A_V2.1.4"}, "name": "thermalperception", "qos": 1, "state_topic": "homeassistant/binary_sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/thermalperception/state", "unique_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_thermalperception", "icon": "mdi:account", "state_class": "measurement"}',
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/thermalperception/config",
+                b'{"availability_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/thermalperception/availability", "device": {"identifiers": ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"], "manufacturer": "Ecowitt", "model": "GW2000A", "name": "GW2000A", "sw_version": "GW2000A_V2.1.4"}, "name": "thermalperception", "qos": 1, "state_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/thermalperception/state", "unique_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_thermalperception", "icon": "mdi:water", "state_class": "measurement"}',
             ),
             call(
-                "homeassistant/binary_sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/thermalperception/availability",
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/thermalperception/availability",
                 b"online",
             ),
             call(
-                "homeassistant/binary_sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/thermalperception/state",
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/thermalperception/state",
                 b"Dry",
             ),
             call(
@@ -4773,15 +4773,15 @@ async def test_no_entity_description(caplog, device_data, ecowitt, setup_asyncio
                 b"44.3",
             ),
             call(
-                "homeassistant/binary_sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/frostrisk/config",
-                b'{"availability_topic": "homeassistant/binary_sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/frostrisk/availability", "device": {"identifiers": ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"], "manufacturer": "Ecowitt", "model": "GW2000A", "name": "GW2000A", "sw_version": "GW2000A_V2.1.4"}, "name": "frostrisk", "qos": 1, "state_topic": "homeassistant/binary_sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/frostrisk/state", "unique_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_frostrisk", "icon": "mdi:snowflake-alert", "state_class": "measurement"}',
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/frostrisk/config",
+                b'{"availability_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/frostrisk/availability", "device": {"identifiers": ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"], "manufacturer": "Ecowitt", "model": "GW2000A", "name": "GW2000A", "sw_version": "GW2000A_V2.1.4"}, "name": "frostrisk", "qos": 1, "state_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/frostrisk/state", "unique_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_frostrisk", "icon": "mdi:snowflake-alert", "state_class": "measurement"}',
             ),
             call(
-                "homeassistant/binary_sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/frostrisk/availability",
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/frostrisk/availability",
                 b"online",
             ),
             call(
-                "homeassistant/binary_sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/frostrisk/state",
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/frostrisk/state",
                 b"No risk",
             ),
             call(
@@ -4941,15 +4941,15 @@ async def test_no_entity_description(caplog, device_data, ecowitt, setup_asyncio
                 b"0.0",
             ),
             call(
-                "homeassistant/binary_sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/thermalperception/config",
-                b'{"availability_topic": "homeassistant/binary_sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/thermalperception/availability", "device": {"identifiers": ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"], "manufacturer": "Ecowitt", "model": "GW2000A", "name": "GW2000A", "sw_version": "GW2000A_V2.1.4"}, "name": "thermalperception", "qos": 1, "state_topic": "homeassistant/binary_sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/thermalperception/state", "unique_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_thermalperception", "icon": "mdi:account", "state_class": "measurement"}',
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/thermalperception/config",
+                b'{"availability_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/thermalperception/availability", "device": {"identifiers": ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"], "manufacturer": "Ecowitt", "model": "GW2000A", "name": "GW2000A", "sw_version": "GW2000A_V2.1.4"}, "name": "thermalperception", "qos": 1, "state_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/thermalperception/state", "unique_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_thermalperception", "icon": "mdi:water", "state_class": "measurement"}',
             ),
             call(
-                "homeassistant/binary_sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/thermalperception/availability",
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/thermalperception/availability",
                 b"online",
             ),
             call(
-                "homeassistant/binary_sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/thermalperception/state",
+                "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/thermalperception/state",
                 b"Dry",
             ),
             call(

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -47,7 +47,7 @@ from ecowitt2mqtt.const import (
     WATER_VAPOR_POUNDS_PER_CUBIC_FOOT,
 )
 from ecowitt2mqtt.data import ProcessedData
-from ecowitt2mqtt.helpers.calculator import CalculatedDataPoint
+from ecowitt2mqtt.helpers.calculator import CalculatedDataPoint, DataPointType
 from ecowitt2mqtt.helpers.calculator.battery import BatteryStrategy, BooleanBatteryState
 from ecowitt2mqtt.helpers.calculator.leak import LeakState
 from ecowitt2mqtt.helpers.calculator.meteo import (
@@ -102,77 +102,206 @@ def test_battery_config(device_data, ecowitt):
     """Test overriding a battery configuration."""
     processed_data = ProcessedData(ecowitt, device_data)
     assert processed_data.output == {
-        "tempin": CalculatedDataPoint("temp", 76.5, unit=TEMP_FAHRENHEIT),
-        "humidityin": CalculatedDataPoint("humidity", 46, unit=PERCENTAGE),
-        "baromrel": CalculatedDataPoint("barom", 29.244, unit=PRESSURE_INHG),
-        "baromabs": CalculatedDataPoint("barom", 29.244, unit=PRESSURE_INHG),
-        "temp": CalculatedDataPoint("temp", 91.4, unit=TEMP_FAHRENHEIT),
-        "humidity": CalculatedDataPoint("humidity", 48, unit=PERCENTAGE),
-        "rainrate": CalculatedDataPoint(
-            "rainrate", 0.000, unit=f"{RAINFALL_INCHES}/hr"
+        "tempin": CalculatedDataPoint(
+            "temp", 76.5, unit=TEMP_FAHRENHEIT, data_type=DataPointType.NON_BOOLEAN
         ),
-        "eventrain": CalculatedDataPoint("rain", 0.000, unit=RAINFALL_INCHES),
-        "hourlyrain": CalculatedDataPoint("rain", 0.000, unit=RAINFALL_INCHES),
-        "dailyrain": CalculatedDataPoint("rain", 0.000, unit=RAINFALL_INCHES),
-        "weeklyrain": CalculatedDataPoint("rain", 0.004, unit=RAINFALL_INCHES),
-        "monthlyrain": CalculatedDataPoint("rain", 1.402, unit=RAINFALL_INCHES),
-        "yearlyrain": CalculatedDataPoint("rain", 48.504, unit=RAINFALL_INCHES),
-        "totalrain": CalculatedDataPoint("rain", 48.504, unit=RAINFALL_INCHES),
-        "temp1": CalculatedDataPoint("temp", 77.7, unit=TEMP_FAHRENHEIT),
-        "humidity1": CalculatedDataPoint("humidity", 51, unit=PERCENTAGE),
-        "soilmoisture1": CalculatedDataPoint("moisture", 40, unit=PERCENTAGE),
-        "soilmoisture2": CalculatedDataPoint("moisture", 56, unit=PERCENTAGE),
-        "wh40batt": CalculatedDataPoint("batt", 1.6, unit=ELECTRIC_POTENTIAL_VOLT),
-        "wh26batt": CalculatedDataPoint("batt", 0.0, unit=PERCENTAGE),
-        "batt1": CalculatedDataPoint("batt", BooleanBatteryState.ON),
-        "soilbatt1": CalculatedDataPoint("batt", 1.5, unit=ELECTRIC_POTENTIAL_VOLT),
-        "soilbatt2": CalculatedDataPoint("batt", 1.8, unit=ELECTRIC_POTENTIAL_VOLT),
-        "tf_ch1": CalculatedDataPoint("tf", 84.7, unit=TEMP_FAHRENHEIT),
-        "tf_batt1": CalculatedDataPoint("batt", 1.6, unit=ELECTRIC_POTENTIAL_VOLT),
-        "tf_ch2": CalculatedDataPoint("tf", 82.9, unit=TEMP_FAHRENHEIT),
-        "tf_batt2": CalculatedDataPoint("batt", 1.47, unit=ELECTRIC_POTENTIAL_VOLT),
-        "tf_ch3": CalculatedDataPoint("tf", 84.0, unit=TEMP_FAHRENHEIT),
-        "tf_batt3": CalculatedDataPoint("batt", 1.6, unit=ELECTRIC_POTENTIAL_VOLT),
-        "tf_ch4": CalculatedDataPoint("tf", 84.2, unit=TEMP_FAHRENHEIT),
-        "tf_batt4": CalculatedDataPoint("batt", 1.6, unit=ELECTRIC_POTENTIAL_VOLT),
-        "tf_ch5": CalculatedDataPoint("tf", 85.1, unit=TEMP_FAHRENHEIT),
-        "tf_batt5": CalculatedDataPoint("batt", 1.2, unit=ELECTRIC_POTENTIAL_VOLT),
-        "tf_ch6": CalculatedDataPoint("tf", 84.2, unit=TEMP_FAHRENHEIT),
-        "tf_batt6": CalculatedDataPoint("batt", 1.77, unit=ELECTRIC_POTENTIAL_VOLT),
-        "tf_ch7": CalculatedDataPoint("tf", 84.3, unit=TEMP_FAHRENHEIT),
-        "tf_batt7": CalculatedDataPoint("batt", 1.6, unit=ELECTRIC_POTENTIAL_VOLT),
-        "tf_ch8": CalculatedDataPoint("tf", 84.2, unit=TEMP_FAHRENHEIT),
-        "tf_batt8": CalculatedDataPoint("batt", 1.3, unit=ELECTRIC_POTENTIAL_VOLT),
-        "dewpoint": CalculatedDataPoint("dewpoint", 68.9, unit=TEMP_FAHRENHEIT),
-        "heatindex": CalculatedDataPoint("heatindex", 96.3, unit=TEMP_FAHRENHEIT),
+        "humidityin": CalculatedDataPoint(
+            "humidity", 46, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "baromrel": CalculatedDataPoint(
+            "barom", 29.244, unit=PRESSURE_INHG, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "baromabs": CalculatedDataPoint(
+            "barom", 29.244, unit=PRESSURE_INHG, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "temp": CalculatedDataPoint(
+            "temp", 91.4, unit=TEMP_FAHRENHEIT, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "humidity": CalculatedDataPoint(
+            "humidity", 48, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "rainrate": CalculatedDataPoint(
+            "rainrate",
+            0.000,
+            unit=f"{RAINFALL_INCHES}/hr",
+            data_type=DataPointType.NON_BOOLEAN,
+        ),
+        "eventrain": CalculatedDataPoint(
+            "rain", 0.000, unit=RAINFALL_INCHES, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "hourlyrain": CalculatedDataPoint(
+            "rain", 0.000, unit=RAINFALL_INCHES, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "dailyrain": CalculatedDataPoint(
+            "rain", 0.000, unit=RAINFALL_INCHES, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "weeklyrain": CalculatedDataPoint(
+            "rain", 0.004, unit=RAINFALL_INCHES, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "monthlyrain": CalculatedDataPoint(
+            "rain", 1.402, unit=RAINFALL_INCHES, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "yearlyrain": CalculatedDataPoint(
+            "rain", 48.504, unit=RAINFALL_INCHES, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "totalrain": CalculatedDataPoint(
+            "rain", 48.504, unit=RAINFALL_INCHES, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "temp1": CalculatedDataPoint(
+            "temp", 77.7, unit=TEMP_FAHRENHEIT, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "humidity1": CalculatedDataPoint(
+            "humidity", 51, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "soilmoisture1": CalculatedDataPoint(
+            "moisture", 40, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "soilmoisture2": CalculatedDataPoint(
+            "moisture", 56, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "wh40batt": CalculatedDataPoint(
+            "batt",
+            1.6,
+            unit=ELECTRIC_POTENTIAL_VOLT,
+            data_type=DataPointType.NON_BOOLEAN,
+        ),
+        "wh26batt": CalculatedDataPoint(
+            "batt", 0.0, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "batt1": CalculatedDataPoint(
+            "batt", BooleanBatteryState.ON, unit=None, data_type=DataPointType.BOOLEAN
+        ),
+        "soilbatt1": CalculatedDataPoint(
+            "batt",
+            1.5,
+            unit=ELECTRIC_POTENTIAL_VOLT,
+            data_type=DataPointType.NON_BOOLEAN,
+        ),
+        "soilbatt2": CalculatedDataPoint(
+            "batt",
+            1.8,
+            unit=ELECTRIC_POTENTIAL_VOLT,
+            data_type=DataPointType.NON_BOOLEAN,
+        ),
+        "tf_ch1": CalculatedDataPoint(
+            "tf", 84.7, unit=TEMP_FAHRENHEIT, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "tf_batt1": CalculatedDataPoint(
+            "batt",
+            1.6,
+            unit=ELECTRIC_POTENTIAL_VOLT,
+            data_type=DataPointType.NON_BOOLEAN,
+        ),
+        "tf_ch2": CalculatedDataPoint(
+            "tf", 82.9, unit=TEMP_FAHRENHEIT, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "tf_batt2": CalculatedDataPoint(
+            "batt",
+            1.47,
+            unit=ELECTRIC_POTENTIAL_VOLT,
+            data_type=DataPointType.NON_BOOLEAN,
+        ),
+        "tf_ch3": CalculatedDataPoint(
+            "tf", 84.0, unit=TEMP_FAHRENHEIT, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "tf_batt3": CalculatedDataPoint(
+            "batt",
+            1.6,
+            unit=ELECTRIC_POTENTIAL_VOLT,
+            data_type=DataPointType.NON_BOOLEAN,
+        ),
+        "tf_ch4": CalculatedDataPoint(
+            "tf", 84.2, unit=TEMP_FAHRENHEIT, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "tf_batt4": CalculatedDataPoint(
+            "batt",
+            1.6,
+            unit=ELECTRIC_POTENTIAL_VOLT,
+            data_type=DataPointType.NON_BOOLEAN,
+        ),
+        "tf_ch5": CalculatedDataPoint(
+            "tf", 85.1, unit=TEMP_FAHRENHEIT, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "tf_batt5": CalculatedDataPoint(
+            "batt",
+            1.2,
+            unit=ELECTRIC_POTENTIAL_VOLT,
+            data_type=DataPointType.NON_BOOLEAN,
+        ),
+        "tf_ch6": CalculatedDataPoint(
+            "tf", 84.2, unit=TEMP_FAHRENHEIT, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "tf_batt6": CalculatedDataPoint(
+            "batt",
+            1.77,
+            unit=ELECTRIC_POTENTIAL_VOLT,
+            data_type=DataPointType.NON_BOOLEAN,
+        ),
+        "tf_ch7": CalculatedDataPoint(
+            "tf", 84.3, unit=TEMP_FAHRENHEIT, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "tf_batt7": CalculatedDataPoint(
+            "batt",
+            1.6,
+            unit=ELECTRIC_POTENTIAL_VOLT,
+            data_type=DataPointType.NON_BOOLEAN,
+        ),
+        "tf_ch8": CalculatedDataPoint(
+            "tf", 84.2, unit=TEMP_FAHRENHEIT, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "tf_batt8": CalculatedDataPoint(
+            "batt",
+            1.3,
+            unit=ELECTRIC_POTENTIAL_VOLT,
+            data_type=DataPointType.NON_BOOLEAN,
+        ),
+        "dewpoint": CalculatedDataPoint(
+            "dewpoint", 68.9, unit=TEMP_FAHRENHEIT, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "heatindex": CalculatedDataPoint(
+            "heatindex", 96.3, unit=TEMP_FAHRENHEIT, data_type=DataPointType.NON_BOOLEAN
+        ),
         "humidityabs": CalculatedDataPoint(
             data_point_key="humidityabs",
             value=0.0,
             unit=WATER_VAPOR_POUNDS_PER_CUBIC_FOOT,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "humidityabsin": CalculatedDataPoint(
             data_point_key="humidityabsin",
             value=0.0,
             unit=WATER_VAPOR_POUNDS_PER_CUBIC_FOOT,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "thermalperception": CalculatedDataPoint(
             data_point_key="thermalperception",
             value=ThermalPerception.SOMEWHAT_UNCOMFORTABLE,
             unit=None,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "frostpoint": CalculatedDataPoint(
-            data_point_key="frostpoint", value=60.3, unit=TEMP_FAHRENHEIT
+            data_point_key="frostpoint",
+            value=60.3,
+            unit=TEMP_FAHRENHEIT,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "frostrisk": CalculatedDataPoint(
-            data_point_key="frostrisk", value=FrostRisk.NO_RISK, unit=None
+            data_point_key="frostrisk",
+            value=FrostRisk.NO_RISK,
+            unit=None,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "simmerindex": CalculatedDataPoint(
-            data_point_key="simmerindex", value=105.2, unit=TEMP_FAHRENHEIT
+            data_point_key="simmerindex",
+            value=105.2,
+            unit=TEMP_FAHRENHEIT,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "simmerzone": CalculatedDataPoint(
             data_point_key="simmerzone",
             value=SimmerZone.CAUTION_HEAT_EXHAUSTION,
             unit=None,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
     }
 
@@ -204,77 +333,212 @@ def test_default_battery_strategy(device_data, ecowitt):
     """Test overriding the default battery configuration."""
     processed_data = ProcessedData(ecowitt, device_data)
     assert processed_data.output == {
-        "tempin": CalculatedDataPoint("temp", 76.5, unit=TEMP_FAHRENHEIT),
-        "humidityin": CalculatedDataPoint("humidity", 46, unit=PERCENTAGE),
-        "baromrel": CalculatedDataPoint("barom", 29.244, unit=PRESSURE_INHG),
-        "baromabs": CalculatedDataPoint("barom", 29.244, unit=PRESSURE_INHG),
-        "temp": CalculatedDataPoint("temp", 91.4, unit=TEMP_FAHRENHEIT),
-        "humidity": CalculatedDataPoint("humidity", 48, unit=PERCENTAGE),
-        "rainrate": CalculatedDataPoint(
-            "rainrate", 0.000, unit=f"{RAINFALL_INCHES}/hr"
+        "tempin": CalculatedDataPoint(
+            "temp", 76.5, unit=TEMP_FAHRENHEIT, data_type=DataPointType.NON_BOOLEAN
         ),
-        "eventrain": CalculatedDataPoint("rain", 0.000, unit=RAINFALL_INCHES),
-        "hourlyrain": CalculatedDataPoint("rain", 0.000, unit=RAINFALL_INCHES),
-        "dailyrain": CalculatedDataPoint("rain", 0.000, unit=RAINFALL_INCHES),
-        "weeklyrain": CalculatedDataPoint("rain", 0.004, unit=RAINFALL_INCHES),
-        "monthlyrain": CalculatedDataPoint("rain", 1.402, unit=RAINFALL_INCHES),
-        "yearlyrain": CalculatedDataPoint("rain", 48.504, unit=RAINFALL_INCHES),
-        "totalrain": CalculatedDataPoint("rain", 48.504, unit=RAINFALL_INCHES),
-        "temp1": CalculatedDataPoint("temp", 77.7, unit=TEMP_FAHRENHEIT),
-        "humidity1": CalculatedDataPoint("humidity", 51, unit=PERCENTAGE),
-        "soilmoisture1": CalculatedDataPoint("moisture", 40, unit=PERCENTAGE),
-        "soilmoisture2": CalculatedDataPoint("moisture", 56, unit=PERCENTAGE),
-        "wh40batt": CalculatedDataPoint("batt", 1.6, unit=ELECTRIC_POTENTIAL_VOLT),
-        "wh26batt": CalculatedDataPoint("batt", BooleanBatteryState.OFF, unit=None),
-        "soilbatt1": CalculatedDataPoint("batt", 1.5, unit=ELECTRIC_POTENTIAL_VOLT),
-        "soilbatt2": CalculatedDataPoint("batt", 1.8, unit=ELECTRIC_POTENTIAL_VOLT),
-        "tf_ch1": CalculatedDataPoint("tf", 84.7, unit=TEMP_FAHRENHEIT),
-        "tf_batt1": CalculatedDataPoint("batt", 1.6, unit=ELECTRIC_POTENTIAL_VOLT),
-        "tf_ch2": CalculatedDataPoint("tf", 82.9, unit=TEMP_FAHRENHEIT),
-        "tf_batt2": CalculatedDataPoint("batt", 1.47, unit=ELECTRIC_POTENTIAL_VOLT),
-        "tf_ch3": CalculatedDataPoint("tf", 84.0, unit=TEMP_FAHRENHEIT),
-        "tf_batt3": CalculatedDataPoint("batt", 1.6, unit=ELECTRIC_POTENTIAL_VOLT),
-        "tf_ch4": CalculatedDataPoint("tf", 84.2, unit=TEMP_FAHRENHEIT),
-        "tf_batt4": CalculatedDataPoint("batt", 1.6, unit=ELECTRIC_POTENTIAL_VOLT),
-        "tf_ch5": CalculatedDataPoint("tf", 85.1, unit=TEMP_FAHRENHEIT),
-        "tf_batt5": CalculatedDataPoint("batt", 1.2, unit=ELECTRIC_POTENTIAL_VOLT),
-        "tf_ch6": CalculatedDataPoint("tf", 84.2, unit=TEMP_FAHRENHEIT),
-        "tf_batt6": CalculatedDataPoint("batt", 1.77, unit=ELECTRIC_POTENTIAL_VOLT),
-        "tf_ch7": CalculatedDataPoint("tf", 84.3, unit=TEMP_FAHRENHEIT),
-        "tf_batt7": CalculatedDataPoint("batt", 1.6, unit=ELECTRIC_POTENTIAL_VOLT),
-        "tf_ch8": CalculatedDataPoint("tf", 84.2, unit=TEMP_FAHRENHEIT),
-        "tf_batt8": CalculatedDataPoint("batt", 1.3, unit=ELECTRIC_POTENTIAL_VOLT),
-        "batt1": CalculatedDataPoint("batt", 1.0, unit=ELECTRIC_POTENTIAL_VOLT),
-        "dewpoint": CalculatedDataPoint("dewpoint", 68.9, unit=TEMP_FAHRENHEIT),
-        "heatindex": CalculatedDataPoint("heatindex", 96.3, unit=TEMP_FAHRENHEIT),
+        "humidityin": CalculatedDataPoint(
+            "humidity", 46, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "baromrel": CalculatedDataPoint(
+            "barom", 29.244, unit=PRESSURE_INHG, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "baromabs": CalculatedDataPoint(
+            "barom", 29.244, unit=PRESSURE_INHG, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "temp": CalculatedDataPoint(
+            "temp", 91.4, unit=TEMP_FAHRENHEIT, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "humidity": CalculatedDataPoint(
+            "humidity", 48, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "rainrate": CalculatedDataPoint(
+            "rainrate",
+            0.000,
+            unit=f"{RAINFALL_INCHES}/hr",
+            data_type=DataPointType.NON_BOOLEAN,
+        ),
+        "eventrain": CalculatedDataPoint(
+            "rain", 0.000, unit=RAINFALL_INCHES, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "hourlyrain": CalculatedDataPoint(
+            "rain", 0.000, unit=RAINFALL_INCHES, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "dailyrain": CalculatedDataPoint(
+            "rain", 0.000, unit=RAINFALL_INCHES, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "weeklyrain": CalculatedDataPoint(
+            "rain", 0.004, unit=RAINFALL_INCHES, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "monthlyrain": CalculatedDataPoint(
+            "rain", 1.402, unit=RAINFALL_INCHES, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "yearlyrain": CalculatedDataPoint(
+            "rain", 48.504, unit=RAINFALL_INCHES, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "totalrain": CalculatedDataPoint(
+            "rain", 48.504, unit=RAINFALL_INCHES, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "temp1": CalculatedDataPoint(
+            "temp", 77.7, unit=TEMP_FAHRENHEIT, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "humidity1": CalculatedDataPoint(
+            "humidity", 51, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "soilmoisture1": CalculatedDataPoint(
+            "moisture", 40, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "soilmoisture2": CalculatedDataPoint(
+            "moisture", 56, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "wh40batt": CalculatedDataPoint(
+            "batt",
+            1.6,
+            unit=ELECTRIC_POTENTIAL_VOLT,
+            data_type=DataPointType.NON_BOOLEAN,
+        ),
+        "wh26batt": CalculatedDataPoint(
+            "batt",
+            BooleanBatteryState.OFF,
+            unit=None,
+            data_type=DataPointType.BOOLEAN,
+        ),
+        "soilbatt1": CalculatedDataPoint(
+            "batt",
+            1.5,
+            unit=ELECTRIC_POTENTIAL_VOLT,
+            data_type=DataPointType.NON_BOOLEAN,
+        ),
+        "soilbatt2": CalculatedDataPoint(
+            "batt",
+            1.8,
+            unit=ELECTRIC_POTENTIAL_VOLT,
+            data_type=DataPointType.NON_BOOLEAN,
+        ),
+        "tf_ch1": CalculatedDataPoint(
+            "tf", 84.7, unit=TEMP_FAHRENHEIT, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "tf_batt1": CalculatedDataPoint(
+            "batt",
+            1.6,
+            unit=ELECTRIC_POTENTIAL_VOLT,
+            data_type=DataPointType.NON_BOOLEAN,
+        ),
+        "tf_ch2": CalculatedDataPoint(
+            "tf", 82.9, unit=TEMP_FAHRENHEIT, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "tf_batt2": CalculatedDataPoint(
+            "batt",
+            1.47,
+            unit=ELECTRIC_POTENTIAL_VOLT,
+            data_type=DataPointType.NON_BOOLEAN,
+        ),
+        "tf_ch3": CalculatedDataPoint(
+            "tf", 84.0, unit=TEMP_FAHRENHEIT, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "tf_batt3": CalculatedDataPoint(
+            "batt",
+            1.6,
+            unit=ELECTRIC_POTENTIAL_VOLT,
+            data_type=DataPointType.NON_BOOLEAN,
+        ),
+        "tf_ch4": CalculatedDataPoint(
+            "tf", 84.2, unit=TEMP_FAHRENHEIT, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "tf_batt4": CalculatedDataPoint(
+            "batt",
+            1.6,
+            unit=ELECTRIC_POTENTIAL_VOLT,
+            data_type=DataPointType.NON_BOOLEAN,
+        ),
+        "tf_ch5": CalculatedDataPoint(
+            "tf", 85.1, unit=TEMP_FAHRENHEIT, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "tf_batt5": CalculatedDataPoint(
+            "batt",
+            1.2,
+            unit=ELECTRIC_POTENTIAL_VOLT,
+            data_type=DataPointType.NON_BOOLEAN,
+        ),
+        "tf_ch6": CalculatedDataPoint(
+            "tf", 84.2, unit=TEMP_FAHRENHEIT, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "tf_batt6": CalculatedDataPoint(
+            "batt",
+            1.77,
+            unit=ELECTRIC_POTENTIAL_VOLT,
+            data_type=DataPointType.NON_BOOLEAN,
+        ),
+        "tf_ch7": CalculatedDataPoint(
+            "tf", 84.3, unit=TEMP_FAHRENHEIT, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "tf_batt7": CalculatedDataPoint(
+            "batt",
+            1.6,
+            unit=ELECTRIC_POTENTIAL_VOLT,
+            data_type=DataPointType.NON_BOOLEAN,
+        ),
+        "tf_ch8": CalculatedDataPoint(
+            "tf", 84.2, unit=TEMP_FAHRENHEIT, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "tf_batt8": CalculatedDataPoint(
+            "batt",
+            1.3,
+            unit=ELECTRIC_POTENTIAL_VOLT,
+            data_type=DataPointType.NON_BOOLEAN,
+        ),
+        "batt1": CalculatedDataPoint(
+            "batt",
+            1.0,
+            unit=ELECTRIC_POTENTIAL_VOLT,
+            data_type=DataPointType.NON_BOOLEAN,
+        ),
+        "dewpoint": CalculatedDataPoint(
+            "dewpoint", 68.9, unit=TEMP_FAHRENHEIT, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "heatindex": CalculatedDataPoint(
+            "heatindex", 96.3, unit=TEMP_FAHRENHEIT, data_type=DataPointType.NON_BOOLEAN
+        ),
         "humidityabs": CalculatedDataPoint(
             data_point_key="humidityabs",
             value=0.0,
             unit=WATER_VAPOR_POUNDS_PER_CUBIC_FOOT,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "humidityabsin": CalculatedDataPoint(
             data_point_key="humidityabsin",
             value=0.0,
             unit=WATER_VAPOR_POUNDS_PER_CUBIC_FOOT,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "thermalperception": CalculatedDataPoint(
             data_point_key="thermalperception",
             value=ThermalPerception.SOMEWHAT_UNCOMFORTABLE,
             unit=None,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "frostpoint": CalculatedDataPoint(
-            data_point_key="frostpoint", value=60.3, unit=TEMP_FAHRENHEIT
+            data_point_key="frostpoint",
+            value=60.3,
+            unit=TEMP_FAHRENHEIT,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "frostrisk": CalculatedDataPoint(
-            data_point_key="frostrisk", value=FrostRisk.NO_RISK, unit=None
+            data_point_key="frostrisk",
+            value=FrostRisk.NO_RISK,
+            unit=None,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "simmerindex": CalculatedDataPoint(
-            data_point_key="simmerindex", value=105.2, unit=TEMP_FAHRENHEIT
+            data_point_key="simmerindex",
+            value=105.2,
+            unit=TEMP_FAHRENHEIT,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "simmerzone": CalculatedDataPoint(
             data_point_key="simmerzone",
             value=SimmerZone.CAUTION_HEAT_EXHAUSTION,
             unit=None,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
     }
 
@@ -322,100 +586,230 @@ def test_missing_distance(device_data, ecowitt, request):
     """Test that a distance key with an invalid value doesn't throw an error."""
     processed_data = ProcessedData(ecowitt, device_data)
     assert processed_data.output == {
-        "runtime": CalculatedDataPoint("runtime", 3179, unit=TIME_SECONDS),
-        "tempin": CalculatedDataPoint("temp", 71.2, unit=TEMP_FAHRENHEIT),
-        "humidityin": CalculatedDataPoint("humidity", 49, unit=PERCENTAGE),
-        "baromrel": CalculatedDataPoint("barom", 28.476, unit=PRESSURE_INHG),
-        "baromabs": CalculatedDataPoint("barom", 28.476, unit=PRESSURE_INHG),
-        "temp": CalculatedDataPoint("temp", 74.5, unit=TEMP_FAHRENHEIT),
-        "humidity": CalculatedDataPoint("humidity", 47, unit=PERCENTAGE),
-        "winddir": CalculatedDataPoint("winddir", 100, unit=DEGREE),
-        "windspeed": CalculatedDataPoint("wind", 1.34, unit=SPEED_MILES_PER_HOUR),
-        "windgust": CalculatedDataPoint("gust", 2.24, unit=SPEED_MILES_PER_HOUR),
-        "maxdailygust": CalculatedDataPoint("gust", 2.24, unit=SPEED_MILES_PER_HOUR),
+        "runtime": CalculatedDataPoint(
+            "runtime", 3179, unit=TIME_SECONDS, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "tempin": CalculatedDataPoint(
+            "temp", 71.2, unit=TEMP_FAHRENHEIT, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "humidityin": CalculatedDataPoint(
+            "humidity", 49, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "baromrel": CalculatedDataPoint(
+            "barom", 28.476, unit=PRESSURE_INHG, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "baromabs": CalculatedDataPoint(
+            "barom", 28.476, unit=PRESSURE_INHG, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "temp": CalculatedDataPoint(
+            "temp", 74.5, unit=TEMP_FAHRENHEIT, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "humidity": CalculatedDataPoint(
+            "humidity", 47, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "winddir": CalculatedDataPoint(
+            "winddir", 100, unit=DEGREE, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "windspeed": CalculatedDataPoint(
+            "wind", 1.34, unit=SPEED_MILES_PER_HOUR, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "windgust": CalculatedDataPoint(
+            "gust", 2.24, unit=SPEED_MILES_PER_HOUR, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "maxdailygust": CalculatedDataPoint(
+            "gust", 2.24, unit=SPEED_MILES_PER_HOUR, data_type=DataPointType.NON_BOOLEAN
+        ),
         "solarradiation": CalculatedDataPoint(
-            "solarradiation", 0.00, unit=IRRADIATION_WATTS_PER_SQUARE_METER
+            "solarradiation",
+            0.00,
+            unit=IRRADIATION_WATTS_PER_SQUARE_METER,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "solarradiation_lux": CalculatedDataPoint(
-            "solarradiation_lux", 0.0, unit=LIGHT_LUX
+            "solarradiation_lux",
+            0.0,
+            unit=LIGHT_LUX,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "solarradiation_perceived": CalculatedDataPoint(
-            "solarradiation_perceived", 0.0, unit=PERCENTAGE
+            "solarradiation_perceived",
+            0.0,
+            unit=PERCENTAGE,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
-        "uv": CalculatedDataPoint("uv", 0, unit=UV_INDEX),
+        "uv": CalculatedDataPoint(
+            "uv", 0, unit=UV_INDEX, data_type=DataPointType.NON_BOOLEAN
+        ),
         "safe_exposure_time_skin_type_1": CalculatedDataPoint(
-            "safe_exposure_time_skin_type_1", None, unit=TIME_MINUTES
+            "safe_exposure_time_skin_type_1",
+            None,
+            unit=TIME_MINUTES,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "safe_exposure_time_skin_type_2": CalculatedDataPoint(
-            "safe_exposure_time_skin_type_2", None, unit=TIME_MINUTES
+            "safe_exposure_time_skin_type_2",
+            None,
+            unit=TIME_MINUTES,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "safe_exposure_time_skin_type_3": CalculatedDataPoint(
-            "safe_exposure_time_skin_type_3", None, unit=TIME_MINUTES
+            "safe_exposure_time_skin_type_3",
+            None,
+            unit=TIME_MINUTES,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "safe_exposure_time_skin_type_4": CalculatedDataPoint(
-            "safe_exposure_time_skin_type_4", None, unit=TIME_MINUTES
+            "safe_exposure_time_skin_type_4",
+            None,
+            unit=TIME_MINUTES,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "safe_exposure_time_skin_type_5": CalculatedDataPoint(
-            "safe_exposure_time_skin_type_5", None, unit=TIME_MINUTES
+            "safe_exposure_time_skin_type_5",
+            None,
+            unit=TIME_MINUTES,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "safe_exposure_time_skin_type_6": CalculatedDataPoint(
-            "safe_exposure_time_skin_type_6", None, unit=TIME_MINUTES
+            "safe_exposure_time_skin_type_6",
+            None,
+            unit=TIME_MINUTES,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "rrain_piezo": CalculatedDataPoint(
-            "rrain", 0.000, unit=f"{RAINFALL_INCHES}/hr"
+            "rrain",
+            0.000,
+            unit=f"{RAINFALL_INCHES}/hr",
+            data_type=DataPointType.NON_BOOLEAN,
         ),
-        "erain_piezo": CalculatedDataPoint("rain", 0.000, unit=RAINFALL_INCHES),
-        "hrain_piezo": CalculatedDataPoint("rain", 0.000, unit=RAINFALL_INCHES),
-        "drain_piezo": CalculatedDataPoint("rain", 0.000, unit=RAINFALL_INCHES),
-        "wrain_piezo": CalculatedDataPoint("rain", 0.000, unit=RAINFALL_INCHES),
-        "mrain_piezo": CalculatedDataPoint("rain", 0.000, unit=RAINFALL_INCHES),
-        "yrain_piezo": CalculatedDataPoint("rain", 0.000, unit=RAINFALL_INCHES),
-        "ws90cap_volt": CalculatedDataPoint("volt", 0.6, unit=ELECTRIC_POTENTIAL_VOLT),
-        "lightning_num": CalculatedDataPoint("lightning_num", 1, unit=STRIKES),
-        "lightning": CalculatedDataPoint("lightning", 16.8, unit=DISTANCE_MILES),
-        "lightning_time": CalculatedDataPoint("lightning_time", None, unit=None),
-        "wh57batt": CalculatedDataPoint("batt", 100, unit=PERCENTAGE),
-        "wh90batt": CalculatedDataPoint("batt", 3.16, unit=ELECTRIC_POTENTIAL_VOLT),
-        "leak_ch1": CalculatedDataPoint("leak", LeakState.OFF, unit=None),
-        "leakbatt1": CalculatedDataPoint("batt", 100, unit=PERCENTAGE),
-        "leak_ch2": CalculatedDataPoint("leak", LeakState.ON, unit=None),
-        "leakbatt2": CalculatedDataPoint("batt", 100, unit=PERCENTAGE),
-        "leak_ch3": CalculatedDataPoint("leak", LeakState.OFF, unit=None),
-        "leakbatt3": CalculatedDataPoint("batt", 100, unit=PERCENTAGE),
-        "leak_ch4": CalculatedDataPoint("leak", LeakState.OFF, unit=None),
-        "leakbatt4": CalculatedDataPoint("batt", 100, unit=PERCENTAGE),
-        "leafwetness_ch1": CalculatedDataPoint("wetness", 14, unit=PERCENTAGE),
-        "leaf_batt1": CalculatedDataPoint("batt", 1.78, unit=ELECTRIC_POTENTIAL_VOLT),
-        "dewpoint": CalculatedDataPoint("dewpoint", 53.0, unit=TEMP_FAHRENHEIT),
-        "feelslike": CalculatedDataPoint("feelslike", 74.5, unit=TEMP_FAHRENHEIT),
-        "heatindex": CalculatedDataPoint("heatindex", 73.9, unit=TEMP_FAHRENHEIT),
-        "windchill": CalculatedDataPoint("windchill", None, unit=TEMP_FAHRENHEIT),
+        "erain_piezo": CalculatedDataPoint(
+            "rain", 0.000, unit=RAINFALL_INCHES, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "hrain_piezo": CalculatedDataPoint(
+            "rain", 0.000, unit=RAINFALL_INCHES, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "drain_piezo": CalculatedDataPoint(
+            "rain", 0.000, unit=RAINFALL_INCHES, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "wrain_piezo": CalculatedDataPoint(
+            "rain", 0.000, unit=RAINFALL_INCHES, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "mrain_piezo": CalculatedDataPoint(
+            "rain", 0.000, unit=RAINFALL_INCHES, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "yrain_piezo": CalculatedDataPoint(
+            "rain", 0.000, unit=RAINFALL_INCHES, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "ws90cap_volt": CalculatedDataPoint(
+            "volt",
+            0.6,
+            unit=ELECTRIC_POTENTIAL_VOLT,
+            data_type=DataPointType.NON_BOOLEAN,
+        ),
+        "lightning_num": CalculatedDataPoint(
+            "lightning_num", 1, unit=STRIKES, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "lightning": CalculatedDataPoint(
+            "lightning", 16.8, unit=DISTANCE_MILES, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "lightning_time": CalculatedDataPoint(
+            "lightning_time", None, unit=None, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "wh57batt": CalculatedDataPoint(
+            "batt", 100, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "wh90batt": CalculatedDataPoint(
+            "batt",
+            3.16,
+            unit=ELECTRIC_POTENTIAL_VOLT,
+            data_type=DataPointType.NON_BOOLEAN,
+        ),
+        "leak_ch1": CalculatedDataPoint(
+            "leak", LeakState.OFF, unit=None, data_type=DataPointType.BOOLEAN
+        ),
+        "leakbatt1": CalculatedDataPoint(
+            "batt", 100, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "leak_ch2": CalculatedDataPoint(
+            "leak", LeakState.ON, unit=None, data_type=DataPointType.BOOLEAN
+        ),
+        "leakbatt2": CalculatedDataPoint(
+            "batt", 100, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "leak_ch3": CalculatedDataPoint(
+            "leak", LeakState.OFF, unit=None, data_type=DataPointType.BOOLEAN
+        ),
+        "leakbatt3": CalculatedDataPoint(
+            "batt", 100, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "leak_ch4": CalculatedDataPoint(
+            "leak", LeakState.OFF, unit=None, data_type=DataPointType.BOOLEAN
+        ),
+        "leakbatt4": CalculatedDataPoint(
+            "batt", 100, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "leafwetness_ch1": CalculatedDataPoint(
+            "wetness", 14, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "leaf_batt1": CalculatedDataPoint(
+            "batt",
+            1.78,
+            unit=ELECTRIC_POTENTIAL_VOLT,
+            data_type=DataPointType.NON_BOOLEAN,
+        ),
+        "dewpoint": CalculatedDataPoint(
+            "dewpoint", 53.0, unit=TEMP_FAHRENHEIT, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "feelslike": CalculatedDataPoint(
+            "feelslike", 74.5, unit=TEMP_FAHRENHEIT, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "heatindex": CalculatedDataPoint(
+            "heatindex", 73.9, unit=TEMP_FAHRENHEIT, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "windchill": CalculatedDataPoint(
+            "windchill", None, unit=TEMP_FAHRENHEIT, data_type=DataPointType.NON_BOOLEAN
+        ),
         "humidityabs": CalculatedDataPoint(
             data_point_key="humidityabs",
             value=0.0,
             unit=WATER_VAPOR_POUNDS_PER_CUBIC_FOOT,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "humidityabsin": CalculatedDataPoint(
             data_point_key="humidityabsin",
             value=0.0,
             unit=WATER_VAPOR_POUNDS_PER_CUBIC_FOOT,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "thermalperception": CalculatedDataPoint(
             data_point_key="thermalperception",
             value=ThermalPerception.VERY_COMFORTABLE,
             unit=None,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "frostpoint": CalculatedDataPoint(
-            data_point_key="frostpoint", value=47.1, unit=TEMP_FAHRENHEIT
+            data_point_key="frostpoint",
+            value=47.1,
+            unit=TEMP_FAHRENHEIT,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "frostrisk": CalculatedDataPoint(
-            data_point_key="frostrisk", value=FrostRisk.NO_RISK, unit=None
+            data_point_key="frostrisk",
+            value=FrostRisk.NO_RISK,
+            unit=None,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "simmerindex": CalculatedDataPoint(
-            data_point_key="simmerindex", value=81.2, unit=TEMP_FAHRENHEIT
+            data_point_key="simmerindex",
+            value=81.2,
+            unit=TEMP_FAHRENHEIT,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "simmerzone": CalculatedDataPoint(
-            data_point_key="simmerzone", value=SimmerZone.COMFORTABLE, unit=None
+            data_point_key="simmerzone",
+            value=SimmerZone.COMFORTABLE,
+            unit=None,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
     }
 
@@ -426,932 +820,2346 @@ def test_missing_distance(device_data, ecowitt, request):
         (
             "payload_gw1000bpro.json",
             {
-                "runtime": CalculatedDataPoint("runtime", 319206.0, unit=TIME_SECONDS),
-                "tempin": CalculatedDataPoint("temp", 79.5, unit=TEMP_FAHRENHEIT),
-                "humidityin": CalculatedDataPoint("humidity", 31.0, unit=PERCENTAGE),
-                "baromrel": CalculatedDataPoint("barom", 24.74, unit=PRESSURE_INHG),
-                "baromabs": CalculatedDataPoint("barom", 24.74, unit=PRESSURE_INHG),
-                "temp": CalculatedDataPoint("temp", 93.2, unit=TEMP_FAHRENHEIT),
-                "humidity": CalculatedDataPoint("humidity", 64, unit=PERCENTAGE),
-                "winddir": CalculatedDataPoint("winddir", 139.0, unit=DEGREE),
+                "runtime": CalculatedDataPoint(
+                    "runtime",
+                    319206.0,
+                    unit=TIME_SECONDS,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "tempin": CalculatedDataPoint(
+                    "temp",
+                    79.5,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "humidityin": CalculatedDataPoint(
+                    "humidity",
+                    31.0,
+                    unit=PERCENTAGE,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "baromrel": CalculatedDataPoint(
+                    "barom",
+                    24.74,
+                    unit=PRESSURE_INHG,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "baromabs": CalculatedDataPoint(
+                    "barom",
+                    24.74,
+                    unit=PRESSURE_INHG,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "temp": CalculatedDataPoint(
+                    "temp",
+                    93.2,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "humidity": CalculatedDataPoint(
+                    "humidity", 64, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+                ),
+                "winddir": CalculatedDataPoint(
+                    "winddir", 139.0, unit=DEGREE, data_type=DataPointType.NON_BOOLEAN
+                ),
                 "windspeed": CalculatedDataPoint(
-                    "wind", 20.89, unit=SPEED_MILES_PER_HOUR
+                    "wind",
+                    20.89,
+                    unit=SPEED_MILES_PER_HOUR,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "windgust": CalculatedDataPoint(
-                    "gust", 1.12, unit=SPEED_MILES_PER_HOUR
+                    "gust",
+                    1.12,
+                    unit=SPEED_MILES_PER_HOUR,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "maxdailygust": CalculatedDataPoint(
-                    "gust", 8.05, unit=SPEED_MILES_PER_HOUR
+                    "gust",
+                    8.05,
+                    unit=SPEED_MILES_PER_HOUR,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "solarradiation": CalculatedDataPoint(
-                    "solarradiation", 264.61, unit=IRRADIATION_WATTS_PER_SQUARE_METER
+                    "solarradiation",
+                    264.61,
+                    unit=IRRADIATION_WATTS_PER_SQUARE_METER,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "solarradiation_lux": CalculatedDataPoint(
-                    "solarradiation_lux", 33494.9, unit=LIGHT_LUX
+                    "solarradiation_lux",
+                    33494.9,
+                    unit=LIGHT_LUX,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "solarradiation_perceived": CalculatedDataPoint(
-                    "solarradiation_perceived", 90.0, unit=PERCENTAGE
+                    "solarradiation_perceived",
+                    90.0,
+                    unit=PERCENTAGE,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
-                "uv": CalculatedDataPoint("uv", 2.0, unit=UV_INDEX),
+                "uv": CalculatedDataPoint(
+                    "uv", 2.0, unit=UV_INDEX, data_type=DataPointType.NON_BOOLEAN
+                ),
                 "safe_exposure_time_skin_type_1": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_1", 83.3, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_1",
+                    83.3,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "safe_exposure_time_skin_type_2": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_2", 100.0, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_2",
+                    100.0,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "safe_exposure_time_skin_type_3": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_3", 133.3, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_3",
+                    133.3,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "safe_exposure_time_skin_type_4": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_4", 166.7, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_4",
+                    166.7,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "safe_exposure_time_skin_type_5": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_5", 266.7, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_5",
+                    266.7,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "safe_exposure_time_skin_type_6": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_6", 433.3, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_6",
+                    433.3,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "rainrate": CalculatedDataPoint(
-                    "rainrate", 0.0, unit=f"{RAINFALL_INCHES}/hr"
+                    "rainrate",
+                    0.0,
+                    unit=f"{RAINFALL_INCHES}/hr",
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
-                "eventrain": CalculatedDataPoint("rain", 0.0, unit=RAINFALL_INCHES),
-                "hourlyrain": CalculatedDataPoint("rain", 0.0, unit=RAINFALL_INCHES),
-                "dailyrain": CalculatedDataPoint("rain", 0.0, unit=RAINFALL_INCHES),
-                "weeklyrain": CalculatedDataPoint("rain", 0.0, unit=RAINFALL_INCHES),
-                "monthlyrain": CalculatedDataPoint("rain", 2.177, unit=RAINFALL_INCHES),
-                "yearlyrain": CalculatedDataPoint("rain", 4.441, unit=RAINFALL_INCHES),
-                "lightning_num": CalculatedDataPoint("lightning_num", 13, unit=STRIKES),
-                "lightning": CalculatedDataPoint("lightning", 0.6, unit=DISTANCE_MILES),
+                "eventrain": CalculatedDataPoint(
+                    "rain",
+                    0.0,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "hourlyrain": CalculatedDataPoint(
+                    "rain",
+                    0.0,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "dailyrain": CalculatedDataPoint(
+                    "rain",
+                    0.0,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "weeklyrain": CalculatedDataPoint(
+                    "rain",
+                    0.0,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "monthlyrain": CalculatedDataPoint(
+                    "rain",
+                    2.177,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "yearlyrain": CalculatedDataPoint(
+                    "rain",
+                    4.441,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "lightning_num": CalculatedDataPoint(
+                    "lightning_num",
+                    13,
+                    unit=STRIKES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "lightning": CalculatedDataPoint(
+                    "lightning",
+                    0.6,
+                    unit=DISTANCE_MILES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
                 "lightning_time": CalculatedDataPoint(
                     "lightning_time",
                     datetime(2022, 4, 20, 17, 17, 17, tzinfo=timezone.utc),
                 ),
-                "wh65batt": CalculatedDataPoint("batt", BooleanBatteryState.OFF),
-                "dewpoint": CalculatedDataPoint("dewpoint", 79.2, unit=TEMP_FAHRENHEIT),
+                "wh65batt": CalculatedDataPoint(
+                    "batt",
+                    BooleanBatteryState.OFF,
+                    unit=None,
+                    data_type=DataPointType.BOOLEAN,
+                ),
+                "dewpoint": CalculatedDataPoint(
+                    "dewpoint",
+                    79.2,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
                 "feelslike": CalculatedDataPoint(
-                    "feelslike", 111.1, unit=TEMP_FAHRENHEIT
+                    "feelslike",
+                    111.1,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "heatindex": CalculatedDataPoint(
-                    "heatindex", 111.1, unit=TEMP_FAHRENHEIT
+                    "heatindex",
+                    111.1,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "windchill": CalculatedDataPoint(
-                    "windchill", None, unit=TEMP_FAHRENHEIT
+                    "windchill",
+                    None,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "humidityabs": CalculatedDataPoint(
                     data_point_key="humidityabs",
                     value=0.0,
                     unit=WATER_VAPOR_POUNDS_PER_CUBIC_FOOT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "humidityabsin": CalculatedDataPoint(
                     data_point_key="humidityabsin",
                     value=0.0,
                     unit=WATER_VAPOR_POUNDS_PER_CUBIC_FOOT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "thermalperception": CalculatedDataPoint(
                     data_point_key="thermalperception",
                     value=ThermalPerception.SEVERELY_HIGH,
                     unit=None,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "frostpoint": CalculatedDataPoint(
-                    data_point_key="frostpoint", value=70.3, unit=TEMP_FAHRENHEIT
+                    data_point_key="frostpoint",
+                    value=70.3,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "frostrisk": CalculatedDataPoint(
-                    data_point_key="frostrisk", value=FrostRisk.NO_RISK, unit=None
+                    data_point_key="frostrisk",
+                    value=FrostRisk.NO_RISK,
+                    unit=None,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "simmerindex": CalculatedDataPoint(
-                    data_point_key="simmerindex", value=113.9, unit=TEMP_FAHRENHEIT
+                    data_point_key="simmerindex",
+                    value=113.9,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "simmerzone": CalculatedDataPoint(
                     data_point_key="simmerzone",
                     value=SimmerZone.DANGER_OF_HEATSTROKE,
                     unit=None,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
             },
         ),
         (
             "payload_gw1000pro.json",
             {
-                "tempin": CalculatedDataPoint("temp", 76.8, unit=TEMP_FAHRENHEIT),
-                "humidityin": CalculatedDataPoint("humidity", 26, unit=PERCENTAGE),
-                "baromrel": CalculatedDataPoint("barom", 24.604, unit=PRESSURE_INHG),
-                "baromabs": CalculatedDataPoint("barom", 24.604, unit=PRESSURE_INHG),
-                "temp": CalculatedDataPoint("temp", 26.7, unit=TEMP_FAHRENHEIT),
-                "humidity": CalculatedDataPoint("humidity", 27, unit=PERCENTAGE),
-                "winddir": CalculatedDataPoint("winddir", 46, unit=DEGREE),
+                "tempin": CalculatedDataPoint(
+                    "temp",
+                    76.8,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "humidityin": CalculatedDataPoint(
+                    "humidity", 26, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+                ),
+                "baromrel": CalculatedDataPoint(
+                    "barom",
+                    24.604,
+                    unit=PRESSURE_INHG,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "baromabs": CalculatedDataPoint(
+                    "barom",
+                    24.604,
+                    unit=PRESSURE_INHG,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "temp": CalculatedDataPoint(
+                    "temp",
+                    26.7,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "humidity": CalculatedDataPoint(
+                    "humidity", 27, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+                ),
+                "winddir": CalculatedDataPoint(
+                    "winddir", 46, unit=DEGREE, data_type=DataPointType.NON_BOOLEAN
+                ),
                 "windspeed": CalculatedDataPoint(
-                    "wind", 22.12, unit=SPEED_MILES_PER_HOUR
+                    "wind",
+                    22.12,
+                    unit=SPEED_MILES_PER_HOUR,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "windgust": CalculatedDataPoint(
-                    "gust", 4.47, unit=SPEED_MILES_PER_HOUR
+                    "gust",
+                    4.47,
+                    unit=SPEED_MILES_PER_HOUR,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "maxdailygust": CalculatedDataPoint(
-                    "gust", 15.88, unit=SPEED_MILES_PER_HOUR
+                    "gust",
+                    15.88,
+                    unit=SPEED_MILES_PER_HOUR,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "solarradiation": CalculatedDataPoint(
-                    "solarradiation", 25.56, unit=IRRADIATION_WATTS_PER_SQUARE_METER
+                    "solarradiation",
+                    25.56,
+                    unit=IRRADIATION_WATTS_PER_SQUARE_METER,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "solarradiation_lux": CalculatedDataPoint(
-                    "solarradiation_lux", 3235.4, unit=LIGHT_LUX
+                    "solarradiation_lux",
+                    3235.4,
+                    unit=LIGHT_LUX,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "solarradiation_perceived": CalculatedDataPoint(
-                    "solarradiation_perceived", 70.0, unit=PERCENTAGE
+                    "solarradiation_perceived",
+                    70.0,
+                    unit=PERCENTAGE,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
-                "uv": CalculatedDataPoint("uv", 0, unit=UV_INDEX),
+                "uv": CalculatedDataPoint(
+                    "uv", 0, unit=UV_INDEX, data_type=DataPointType.NON_BOOLEAN
+                ),
                 "safe_exposure_time_skin_type_1": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_1", None, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_1",
+                    None,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "safe_exposure_time_skin_type_2": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_2", None, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_2",
+                    None,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "safe_exposure_time_skin_type_3": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_3", None, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_3",
+                    None,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "safe_exposure_time_skin_type_4": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_4", None, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_4",
+                    None,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "safe_exposure_time_skin_type_5": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_5", None, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_5",
+                    None,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "safe_exposure_time_skin_type_6": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_6", None, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_6",
+                    None,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "rainrate": CalculatedDataPoint(
-                    "rainrate", 0.000, unit=f"{RAINFALL_INCHES}/hr"
+                    "rainrate",
+                    0.000,
+                    unit=f"{RAINFALL_INCHES}/hr",
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
-                "eventrain": CalculatedDataPoint("rain", 0.000, unit=RAINFALL_INCHES),
-                "hourlyrain": CalculatedDataPoint("rain", 0.000, unit=RAINFALL_INCHES),
-                "dailyrain": CalculatedDataPoint("rain", 0.000, unit=RAINFALL_INCHES),
-                "weeklyrain": CalculatedDataPoint("rain", 0.000, unit=RAINFALL_INCHES),
-                "monthlyrain": CalculatedDataPoint("rain", 0.000, unit=RAINFALL_INCHES),
-                "yearlyrain": CalculatedDataPoint("rain", 11.756, unit=RAINFALL_INCHES),
-                "totalrain": CalculatedDataPoint("rain", 11.756, unit=RAINFALL_INCHES),
-                "wh65batt": CalculatedDataPoint("batt", BooleanBatteryState.OFF),
-                "dewpoint": CalculatedDataPoint("dewpoint", -2.8, unit=TEMP_FAHRENHEIT),
+                "eventrain": CalculatedDataPoint(
+                    "rain",
+                    0.000,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "hourlyrain": CalculatedDataPoint(
+                    "rain",
+                    0.000,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "dailyrain": CalculatedDataPoint(
+                    "rain",
+                    0.000,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "weeklyrain": CalculatedDataPoint(
+                    "rain",
+                    0.000,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "monthlyrain": CalculatedDataPoint(
+                    "rain",
+                    0.000,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "yearlyrain": CalculatedDataPoint(
+                    "rain",
+                    11.756,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "totalrain": CalculatedDataPoint(
+                    "rain",
+                    11.756,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "wh65batt": CalculatedDataPoint(
+                    "batt",
+                    BooleanBatteryState.OFF,
+                    unit=None,
+                    data_type=DataPointType.BOOLEAN,
+                ),
+                "dewpoint": CalculatedDataPoint(
+                    "dewpoint",
+                    -2.8,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
                 "feelslike": CalculatedDataPoint(
-                    "feelslike", 12.4, unit=TEMP_FAHRENHEIT
+                    "feelslike",
+                    12.4,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "heatindex": CalculatedDataPoint(
-                    "heatindex", 20.3, unit=TEMP_FAHRENHEIT
+                    "heatindex",
+                    20.3,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "windchill": CalculatedDataPoint(
-                    "windchill", 12.4, unit=TEMP_FAHRENHEIT
+                    "windchill",
+                    12.4,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "humidityabs": CalculatedDataPoint(
                     data_point_key="humidityabs",
                     value=0.0,
                     unit=WATER_VAPOR_POUNDS_PER_CUBIC_FOOT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "humidityabsin": CalculatedDataPoint(
                     data_point_key="humidityabsin",
                     value=0.0,
                     unit=WATER_VAPOR_POUNDS_PER_CUBIC_FOOT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "thermalperception": CalculatedDataPoint(
                     data_point_key="thermalperception",
                     value=ThermalPerception.DRY,
                     unit=None,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "frostpoint": CalculatedDataPoint(
-                    data_point_key="frostpoint", value=-2.2, unit=TEMP_FAHRENHEIT
+                    data_point_key="frostpoint",
+                    value=-2.2,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "frostrisk": CalculatedDataPoint(
-                    data_point_key="frostrisk", value=FrostRisk.UNLIKELY, unit=None
+                    data_point_key="frostrisk",
+                    value=FrostRisk.UNLIKELY,
+                    unit=None,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "simmerindex": CalculatedDataPoint(
-                    data_point_key="simmerindex", value=None, unit=TEMP_FAHRENHEIT
+                    data_point_key="simmerindex",
+                    value=None,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "simmerzone": CalculatedDataPoint(
-                    data_point_key="simmerzone", value=None, unit=None
+                    data_point_key="simmerzone",
+                    value=None,
+                    unit=None,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
             },
         ),
         (
             "payload_gw1100b.json",
             {
-                "tempin": CalculatedDataPoint("temp", 76.5, unit=TEMP_FAHRENHEIT),
-                "humidityin": CalculatedDataPoint("humidity", 46, unit=PERCENTAGE),
-                "baromrel": CalculatedDataPoint("barom", 29.244, unit=PRESSURE_INHG),
-                "baromabs": CalculatedDataPoint("barom", 29.244, unit=PRESSURE_INHG),
-                "temp": CalculatedDataPoint("temp", 91.4, unit=TEMP_FAHRENHEIT),
-                "humidity": CalculatedDataPoint("humidity", 48, unit=PERCENTAGE),
+                "tempin": CalculatedDataPoint(
+                    "temp",
+                    76.5,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "humidityin": CalculatedDataPoint(
+                    "humidity", 46, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+                ),
+                "baromrel": CalculatedDataPoint(
+                    "barom",
+                    29.244,
+                    unit=PRESSURE_INHG,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "baromabs": CalculatedDataPoint(
+                    "barom",
+                    29.244,
+                    unit=PRESSURE_INHG,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "temp": CalculatedDataPoint(
+                    "temp",
+                    91.4,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "humidity": CalculatedDataPoint(
+                    "humidity", 48, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+                ),
                 "rainrate": CalculatedDataPoint(
-                    "rainrate", 0.000, unit=f"{RAINFALL_INCHES}/hr"
+                    "rainrate",
+                    0.000,
+                    unit=f"{RAINFALL_INCHES}/hr",
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
-                "eventrain": CalculatedDataPoint("rain", 0.000, unit=RAINFALL_INCHES),
-                "hourlyrain": CalculatedDataPoint("rain", 0.000, unit=RAINFALL_INCHES),
-                "dailyrain": CalculatedDataPoint("rain", 0.000, unit=RAINFALL_INCHES),
-                "weeklyrain": CalculatedDataPoint("rain", 0.004, unit=RAINFALL_INCHES),
-                "monthlyrain": CalculatedDataPoint("rain", 1.402, unit=RAINFALL_INCHES),
-                "yearlyrain": CalculatedDataPoint("rain", 48.504, unit=RAINFALL_INCHES),
-                "totalrain": CalculatedDataPoint("rain", 48.504, unit=RAINFALL_INCHES),
-                "temp1": CalculatedDataPoint("temp", 77.7, unit=TEMP_FAHRENHEIT),
-                "humidity1": CalculatedDataPoint("humidity", 51, unit=PERCENTAGE),
-                "soilmoisture1": CalculatedDataPoint("moisture", 40, unit=PERCENTAGE),
-                "soilmoisture2": CalculatedDataPoint("moisture", 56, unit=PERCENTAGE),
+                "eventrain": CalculatedDataPoint(
+                    "rain",
+                    0.000,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "hourlyrain": CalculatedDataPoint(
+                    "rain",
+                    0.000,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "dailyrain": CalculatedDataPoint(
+                    "rain",
+                    0.000,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "weeklyrain": CalculatedDataPoint(
+                    "rain",
+                    0.004,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "monthlyrain": CalculatedDataPoint(
+                    "rain",
+                    1.402,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "yearlyrain": CalculatedDataPoint(
+                    "rain",
+                    48.504,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "totalrain": CalculatedDataPoint(
+                    "rain",
+                    48.504,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "temp1": CalculatedDataPoint(
+                    "temp",
+                    77.7,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "humidity1": CalculatedDataPoint(
+                    "humidity", 51, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+                ),
+                "soilmoisture1": CalculatedDataPoint(
+                    "moisture", 40, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+                ),
+                "soilmoisture2": CalculatedDataPoint(
+                    "moisture", 56, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+                ),
                 "wh40batt": CalculatedDataPoint(
-                    "batt", 1.6, unit=ELECTRIC_POTENTIAL_VOLT
+                    "batt",
+                    1.6,
+                    unit=ELECTRIC_POTENTIAL_VOLT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
-                "wh26batt": CalculatedDataPoint("batt", BooleanBatteryState.OFF),
-                "batt1": CalculatedDataPoint("batt", BooleanBatteryState.ON),
+                "wh26batt": CalculatedDataPoint(
+                    "batt",
+                    BooleanBatteryState.OFF,
+                    unit=None,
+                    data_type=DataPointType.BOOLEAN,
+                ),
+                "batt1": CalculatedDataPoint(
+                    "batt",
+                    BooleanBatteryState.ON,
+                    unit=None,
+                    data_type=DataPointType.BOOLEAN,
+                ),
                 "soilbatt1": CalculatedDataPoint(
-                    "batt", 1.5, unit=ELECTRIC_POTENTIAL_VOLT
+                    "batt",
+                    1.5,
+                    unit=ELECTRIC_POTENTIAL_VOLT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "soilbatt2": CalculatedDataPoint(
-                    "batt", 1.8, unit=ELECTRIC_POTENTIAL_VOLT
+                    "batt",
+                    1.8,
+                    unit=ELECTRIC_POTENTIAL_VOLT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
-                "tf_ch1": CalculatedDataPoint("tf", 84.7, unit=TEMP_FAHRENHEIT),
+                "tf_ch1": CalculatedDataPoint(
+                    "tf",
+                    84.7,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
                 "tf_batt1": CalculatedDataPoint(
-                    "batt", 1.6, unit=ELECTRIC_POTENTIAL_VOLT
+                    "batt",
+                    1.6,
+                    unit=ELECTRIC_POTENTIAL_VOLT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
-                "tf_ch2": CalculatedDataPoint("tf", 82.9, unit=TEMP_FAHRENHEIT),
+                "tf_ch2": CalculatedDataPoint(
+                    "tf",
+                    82.9,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
                 "tf_batt2": CalculatedDataPoint(
-                    "batt", 1.47, unit=ELECTRIC_POTENTIAL_VOLT
+                    "batt",
+                    1.47,
+                    unit=ELECTRIC_POTENTIAL_VOLT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
-                "tf_ch3": CalculatedDataPoint("tf", 84.0, unit=TEMP_FAHRENHEIT),
+                "tf_ch3": CalculatedDataPoint(
+                    "tf",
+                    84.0,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
                 "tf_batt3": CalculatedDataPoint(
-                    "batt", 1.6, unit=ELECTRIC_POTENTIAL_VOLT
+                    "batt",
+                    1.6,
+                    unit=ELECTRIC_POTENTIAL_VOLT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
-                "tf_ch4": CalculatedDataPoint("tf", 84.2, unit=TEMP_FAHRENHEIT),
+                "tf_ch4": CalculatedDataPoint(
+                    "tf",
+                    84.2,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
                 "tf_batt4": CalculatedDataPoint(
-                    "batt", 1.6, unit=ELECTRIC_POTENTIAL_VOLT
+                    "batt",
+                    1.6,
+                    unit=ELECTRIC_POTENTIAL_VOLT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
-                "tf_ch5": CalculatedDataPoint("tf", 85.1, unit=TEMP_FAHRENHEIT),
+                "tf_ch5": CalculatedDataPoint(
+                    "tf",
+                    85.1,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
                 "tf_batt5": CalculatedDataPoint(
-                    "batt", 1.2, unit=ELECTRIC_POTENTIAL_VOLT
+                    "batt",
+                    1.2,
+                    unit=ELECTRIC_POTENTIAL_VOLT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
-                "tf_ch6": CalculatedDataPoint("tf", 84.2, unit=TEMP_FAHRENHEIT),
+                "tf_ch6": CalculatedDataPoint(
+                    "tf",
+                    84.2,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
                 "tf_batt6": CalculatedDataPoint(
-                    "batt", 1.77, unit=ELECTRIC_POTENTIAL_VOLT
+                    "batt",
+                    1.77,
+                    unit=ELECTRIC_POTENTIAL_VOLT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
-                "tf_ch7": CalculatedDataPoint("tf", 84.3, unit=TEMP_FAHRENHEIT),
+                "tf_ch7": CalculatedDataPoint(
+                    "tf",
+                    84.3,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
                 "tf_batt7": CalculatedDataPoint(
-                    "batt", 1.6, unit=ELECTRIC_POTENTIAL_VOLT
+                    "batt",
+                    1.6,
+                    unit=ELECTRIC_POTENTIAL_VOLT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
-                "tf_ch8": CalculatedDataPoint("tf", 84.2, unit=TEMP_FAHRENHEIT),
+                "tf_ch8": CalculatedDataPoint(
+                    "tf",
+                    84.2,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
                 "tf_batt8": CalculatedDataPoint(
-                    "batt", 1.3, unit=ELECTRIC_POTENTIAL_VOLT
+                    "batt",
+                    1.3,
+                    unit=ELECTRIC_POTENTIAL_VOLT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
-                "dewpoint": CalculatedDataPoint("dewpoint", 68.9, unit=TEMP_FAHRENHEIT),
+                "dewpoint": CalculatedDataPoint(
+                    "dewpoint",
+                    68.9,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
                 "heatindex": CalculatedDataPoint(
-                    "heatindex", 96.3, unit=TEMP_FAHRENHEIT
+                    "heatindex",
+                    96.3,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "humidityabs": CalculatedDataPoint(
                     data_point_key="humidityabs",
                     value=0.0,
                     unit=WATER_VAPOR_POUNDS_PER_CUBIC_FOOT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "humidityabsin": CalculatedDataPoint(
                     data_point_key="humidityabsin",
                     value=0.0,
                     unit=WATER_VAPOR_POUNDS_PER_CUBIC_FOOT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "thermalperception": CalculatedDataPoint(
                     data_point_key="thermalperception",
                     value=ThermalPerception.SOMEWHAT_UNCOMFORTABLE,
                     unit=None,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "frostpoint": CalculatedDataPoint(
-                    data_point_key="frostpoint", value=60.3, unit=TEMP_FAHRENHEIT
+                    data_point_key="frostpoint",
+                    value=60.3,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "frostrisk": CalculatedDataPoint(
-                    data_point_key="frostrisk", value=FrostRisk.NO_RISK, unit=None
+                    data_point_key="frostrisk",
+                    value=FrostRisk.NO_RISK,
+                    unit=None,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "simmerindex": CalculatedDataPoint(
-                    data_point_key="simmerindex", value=105.2, unit=TEMP_FAHRENHEIT
+                    data_point_key="simmerindex",
+                    value=105.2,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "simmerzone": CalculatedDataPoint(
                     data_point_key="simmerzone",
                     value=SimmerZone.CAUTION_HEAT_EXHAUSTION,
                     unit=None,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
             },
         ),
         (
             "payload_gw2000a_1.json",
             {
-                "runtime": CalculatedDataPoint("runtime", 3179, unit=TIME_SECONDS),
-                "tempin": CalculatedDataPoint("temp", 71.2, unit=TEMP_FAHRENHEIT),
-                "humidityin": CalculatedDataPoint("humidity", 49, unit=PERCENTAGE),
-                "baromrel": CalculatedDataPoint("barom", 28.476, unit=PRESSURE_INHG),
-                "baromabs": CalculatedDataPoint("barom", 28.476, unit=PRESSURE_INHG),
-                "temp": CalculatedDataPoint("temp", 74.5, unit=TEMP_FAHRENHEIT),
-                "humidity": CalculatedDataPoint("humidity", 47, unit=PERCENTAGE),
-                "winddir": CalculatedDataPoint("winddir", 100, unit=DEGREE),
+                "runtime": CalculatedDataPoint(
+                    "runtime",
+                    3179,
+                    unit=TIME_SECONDS,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "tempin": CalculatedDataPoint(
+                    "temp",
+                    71.2,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "humidityin": CalculatedDataPoint(
+                    "humidity", 49, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+                ),
+                "baromrel": CalculatedDataPoint(
+                    "barom",
+                    28.476,
+                    unit=PRESSURE_INHG,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "baromabs": CalculatedDataPoint(
+                    "barom",
+                    28.476,
+                    unit=PRESSURE_INHG,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "temp": CalculatedDataPoint(
+                    "temp",
+                    74.5,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "humidity": CalculatedDataPoint(
+                    "humidity", 47, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+                ),
+                "winddir": CalculatedDataPoint(
+                    "winddir", 100, unit=DEGREE, data_type=DataPointType.NON_BOOLEAN
+                ),
                 "windspeed": CalculatedDataPoint(
-                    "wind", 1.34, unit=SPEED_MILES_PER_HOUR
+                    "wind",
+                    1.34,
+                    unit=SPEED_MILES_PER_HOUR,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "windgust": CalculatedDataPoint(
-                    "gust", 2.24, unit=SPEED_MILES_PER_HOUR
+                    "gust",
+                    2.24,
+                    unit=SPEED_MILES_PER_HOUR,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "maxdailygust": CalculatedDataPoint(
-                    "gust", 2.24, unit=SPEED_MILES_PER_HOUR
+                    "gust",
+                    2.24,
+                    unit=SPEED_MILES_PER_HOUR,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "solarradiation": CalculatedDataPoint(
-                    "solarradiation", 0.0, unit=IRRADIATION_WATTS_PER_SQUARE_METER
+                    "solarradiation",
+                    0.0,
+                    unit=IRRADIATION_WATTS_PER_SQUARE_METER,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "solarradiation_lux": CalculatedDataPoint(
-                    "solarradiation_lux", 0.0, unit=LIGHT_LUX
+                    "solarradiation_lux",
+                    0.0,
+                    unit=LIGHT_LUX,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "solarradiation_perceived": CalculatedDataPoint(
-                    "solarradiation_perceived", 0.0, unit=PERCENTAGE
+                    "solarradiation_perceived",
+                    0.0,
+                    unit=PERCENTAGE,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
-                "uv": CalculatedDataPoint("uv", 0, unit=UV_INDEX),
+                "uv": CalculatedDataPoint(
+                    "uv", 0, unit=UV_INDEX, data_type=DataPointType.NON_BOOLEAN
+                ),
                 "safe_exposure_time_skin_type_1": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_1", None, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_1",
+                    None,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "safe_exposure_time_skin_type_2": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_2", None, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_2",
+                    None,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "safe_exposure_time_skin_type_3": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_3", None, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_3",
+                    None,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "safe_exposure_time_skin_type_4": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_4", None, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_4",
+                    None,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "safe_exposure_time_skin_type_5": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_5", None, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_5",
+                    None,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "safe_exposure_time_skin_type_6": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_6", None, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_6",
+                    None,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "rrain_piezo": CalculatedDataPoint(
-                    "rrain", 0.000, unit=f"{RAINFALL_INCHES}/hr"
+                    "rrain",
+                    0.000,
+                    unit=f"{RAINFALL_INCHES}/hr",
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
-                "erain_piezo": CalculatedDataPoint("rain", 0.000, unit=RAINFALL_INCHES),
-                "hrain_piezo": CalculatedDataPoint("rain", 0.000, unit=RAINFALL_INCHES),
-                "drain_piezo": CalculatedDataPoint("rain", 0.000, unit=RAINFALL_INCHES),
-                "wrain_piezo": CalculatedDataPoint("rain", 0.000, unit=RAINFALL_INCHES),
-                "mrain_piezo": CalculatedDataPoint("rain", 0.000, unit=RAINFALL_INCHES),
-                "yrain_piezo": CalculatedDataPoint("rain", 0.000, unit=RAINFALL_INCHES),
+                "erain_piezo": CalculatedDataPoint(
+                    "rain",
+                    0.000,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "hrain_piezo": CalculatedDataPoint(
+                    "rain",
+                    0.000,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "drain_piezo": CalculatedDataPoint(
+                    "rain",
+                    0.000,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "wrain_piezo": CalculatedDataPoint(
+                    "rain",
+                    0.000,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "mrain_piezo": CalculatedDataPoint(
+                    "rain",
+                    0.000,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "yrain_piezo": CalculatedDataPoint(
+                    "rain",
+                    0.000,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
                 "ws90cap_volt": CalculatedDataPoint(
-                    "volt", 0.6, unit=ELECTRIC_POTENTIAL_VOLT
+                    "volt",
+                    0.6,
+                    unit=ELECTRIC_POTENTIAL_VOLT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
-                "lightning_num": CalculatedDataPoint("lightning_num", 1, unit=STRIKES),
+                "lightning_num": CalculatedDataPoint(
+                    "lightning_num",
+                    1,
+                    unit=STRIKES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
                 "lightning": CalculatedDataPoint(
-                    "lightning", 16.8, unit=DISTANCE_MILES
+                    "lightning",
+                    16.8,
+                    unit=DISTANCE_MILES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "lightning_time": CalculatedDataPoint(
-                    "lightning_time", None, unit=None
+                    "lightning_time",
+                    None,
+                    unit=None,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
-                "wh57batt": CalculatedDataPoint("batt", 100, unit=PERCENTAGE),
+                "wh57batt": CalculatedDataPoint(
+                    "batt", 100, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+                ),
                 "wh90batt": CalculatedDataPoint(
-                    "batt", 3.16, unit=ELECTRIC_POTENTIAL_VOLT
+                    "batt",
+                    3.16,
+                    unit=ELECTRIC_POTENTIAL_VOLT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
-                "leak_ch1": CalculatedDataPoint("leak", LeakState.OFF, unit=None),
-                "leakbatt1": CalculatedDataPoint("batt", 100, unit=PERCENTAGE),
-                "leak_ch2": CalculatedDataPoint("leak", LeakState.ON, unit=None),
-                "leakbatt2": CalculatedDataPoint("batt", 100, unit=PERCENTAGE),
-                "leak_ch3": CalculatedDataPoint("leak", LeakState.OFF, unit=None),
-                "leakbatt3": CalculatedDataPoint("batt", 100, unit=PERCENTAGE),
-                "leak_ch4": CalculatedDataPoint("leak", LeakState.OFF, unit=None),
-                "leakbatt4": CalculatedDataPoint("batt", 100, unit=PERCENTAGE),
-                "leafwetness_ch1": CalculatedDataPoint("wetness", 14, unit=PERCENTAGE),
+                "leak_ch1": CalculatedDataPoint(
+                    "leak", LeakState.OFF, unit=None, data_type=DataPointType.BOOLEAN
+                ),
+                "leakbatt1": CalculatedDataPoint(
+                    "batt", 100, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+                ),
+                "leak_ch2": CalculatedDataPoint(
+                    "leak", LeakState.ON, unit=None, data_type=DataPointType.BOOLEAN
+                ),
+                "leakbatt2": CalculatedDataPoint(
+                    "batt", 100, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+                ),
+                "leak_ch3": CalculatedDataPoint(
+                    "leak", LeakState.OFF, unit=None, data_type=DataPointType.BOOLEAN
+                ),
+                "leakbatt3": CalculatedDataPoint(
+                    "batt", 100, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+                ),
+                "leak_ch4": CalculatedDataPoint(
+                    "leak", LeakState.OFF, unit=None, data_type=DataPointType.BOOLEAN
+                ),
+                "leakbatt4": CalculatedDataPoint(
+                    "batt", 100, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+                ),
+                "leafwetness_ch1": CalculatedDataPoint(
+                    "wetness", 14, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+                ),
                 "leaf_batt1": CalculatedDataPoint(
-                    "batt", 1.78, unit=ELECTRIC_POTENTIAL_VOLT
+                    "batt",
+                    1.78,
+                    unit=ELECTRIC_POTENTIAL_VOLT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
-                "dewpoint": CalculatedDataPoint("dewpoint", 53.0, unit=TEMP_FAHRENHEIT),
+                "dewpoint": CalculatedDataPoint(
+                    "dewpoint",
+                    53.0,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
                 "feelslike": CalculatedDataPoint(
-                    "feelslike", 74.5, unit=TEMP_FAHRENHEIT
+                    "feelslike",
+                    74.5,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "heatindex": CalculatedDataPoint(
-                    "heatindex", 73.9, unit=TEMP_FAHRENHEIT
+                    "heatindex",
+                    73.9,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "windchill": CalculatedDataPoint(
-                    "windchill", None, unit=TEMP_FAHRENHEIT
+                    "windchill",
+                    None,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "humidityabs": CalculatedDataPoint(
                     data_point_key="humidityabs",
                     value=0.0,
                     unit=WATER_VAPOR_POUNDS_PER_CUBIC_FOOT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "humidityabsin": CalculatedDataPoint(
                     data_point_key="humidityabsin",
                     value=0.0,
                     unit=WATER_VAPOR_POUNDS_PER_CUBIC_FOOT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "thermalperception": CalculatedDataPoint(
                     data_point_key="thermalperception",
                     value=ThermalPerception.VERY_COMFORTABLE,
                     unit=None,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "frostpoint": CalculatedDataPoint(
-                    data_point_key="frostpoint", value=47.1, unit=TEMP_FAHRENHEIT
+                    data_point_key="frostpoint",
+                    value=47.1,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "frostrisk": CalculatedDataPoint(
-                    data_point_key="frostrisk", value=FrostRisk.NO_RISK, unit=None
+                    data_point_key="frostrisk",
+                    value=FrostRisk.NO_RISK,
+                    unit=None,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "simmerindex": CalculatedDataPoint(
-                    data_point_key="simmerindex", value=81.2, unit=TEMP_FAHRENHEIT
+                    data_point_key="simmerindex",
+                    value=81.2,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "simmerzone": CalculatedDataPoint(
-                    data_point_key="simmerzone", value=SimmerZone.COMFORTABLE, unit=None
+                    data_point_key="simmerzone",
+                    value=SimmerZone.COMFORTABLE,
+                    unit=None,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
             },
         ),
         (
             "payload_gw2000a_2.json",
             {
-                "runtime": CalculatedDataPoint("runtime", 436796, unit=TIME_SECONDS),
-                "tempin": CalculatedDataPoint("temp", 72.9, unit=TEMP_FAHRENHEIT),
-                "humidityin": CalculatedDataPoint("humidity", 56, unit=PERCENTAGE),
-                "baromrel": CalculatedDataPoint("barom", 29.870, unit=PRESSURE_INHG),
-                "baromabs": CalculatedDataPoint("barom", 29.509, unit=PRESSURE_INHG),
-                "temp": CalculatedDataPoint("temp", 59.7, unit=TEMP_FAHRENHEIT),
-                "humidity": CalculatedDataPoint("humidity", 65, unit=PERCENTAGE),
-                "winddir": CalculatedDataPoint("winddir", 327, unit=DEGREE),
+                "runtime": CalculatedDataPoint(
+                    "runtime",
+                    436796,
+                    unit=TIME_SECONDS,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "tempin": CalculatedDataPoint(
+                    "temp",
+                    72.9,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "humidityin": CalculatedDataPoint(
+                    "humidity", 56, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+                ),
+                "baromrel": CalculatedDataPoint(
+                    "barom",
+                    29.870,
+                    unit=PRESSURE_INHG,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "baromabs": CalculatedDataPoint(
+                    "barom",
+                    29.509,
+                    unit=PRESSURE_INHG,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "temp": CalculatedDataPoint(
+                    "temp",
+                    59.7,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "humidity": CalculatedDataPoint(
+                    "humidity", 65, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+                ),
+                "winddir": CalculatedDataPoint(
+                    "winddir", 327, unit=DEGREE, data_type=DataPointType.NON_BOOLEAN
+                ),
                 "windspeed": CalculatedDataPoint(
-                    "wind", 2.24, unit=SPEED_MILES_PER_HOUR
+                    "wind",
+                    2.24,
+                    unit=SPEED_MILES_PER_HOUR,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "windgust": CalculatedDataPoint(
-                    "gust", 3.80, unit=SPEED_MILES_PER_HOUR
+                    "gust",
+                    3.80,
+                    unit=SPEED_MILES_PER_HOUR,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "maxdailygust": CalculatedDataPoint(
-                    "gust", 17.45, unit=SPEED_MILES_PER_HOUR
+                    "gust",
+                    17.45,
+                    unit=SPEED_MILES_PER_HOUR,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "solarradiation": CalculatedDataPoint(
-                    "solarradiation", 0.00, unit=IRRADIATION_WATTS_PER_SQUARE_METER
+                    "solarradiation",
+                    0.00,
+                    unit=IRRADIATION_WATTS_PER_SQUARE_METER,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "solarradiation_lux": CalculatedDataPoint(
-                    "solarradiation_lux", 0.0, unit=LIGHT_LUX
+                    "solarradiation_lux",
+                    0.0,
+                    unit=LIGHT_LUX,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "solarradiation_perceived": CalculatedDataPoint(
-                    "solarradiation_perceived", 0.0, unit=PERCENTAGE
+                    "solarradiation_perceived",
+                    0.0,
+                    unit=PERCENTAGE,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
-                "uv": CalculatedDataPoint("uv", 0, unit=UV_INDEX),
+                "uv": CalculatedDataPoint(
+                    "uv", 0, unit=UV_INDEX, data_type=DataPointType.NON_BOOLEAN
+                ),
                 "safe_exposure_time_skin_type_1": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_1", None, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_1",
+                    None,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "safe_exposure_time_skin_type_2": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_2", None, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_2",
+                    None,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "safe_exposure_time_skin_type_3": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_3", None, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_3",
+                    None,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "safe_exposure_time_skin_type_4": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_4", None, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_4",
+                    None,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "safe_exposure_time_skin_type_5": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_5", None, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_5",
+                    None,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "safe_exposure_time_skin_type_6": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_6", None, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_6",
+                    None,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "rainrate": CalculatedDataPoint(
-                    "rainrate", 0.000, unit=f"{RAINFALL_INCHES}/hr"
+                    "rainrate",
+                    0.000,
+                    unit=f"{RAINFALL_INCHES}/hr",
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
-                "eventrain": CalculatedDataPoint("rain", 0.000, unit=RAINFALL_INCHES),
-                "hourlyrain": CalculatedDataPoint("rain", 0.000, unit=RAINFALL_INCHES),
-                "dailyrain": CalculatedDataPoint("rain", 0.000, unit=RAINFALL_INCHES),
-                "weeklyrain": CalculatedDataPoint("rain", 0.000, unit=RAINFALL_INCHES),
-                "monthlyrain": CalculatedDataPoint("rain", 0.736, unit=RAINFALL_INCHES),
-                "yearlyrain": CalculatedDataPoint("rain", 3.909, unit=RAINFALL_INCHES),
+                "eventrain": CalculatedDataPoint(
+                    "rain",
+                    0.000,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "hourlyrain": CalculatedDataPoint(
+                    "rain",
+                    0.000,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "dailyrain": CalculatedDataPoint(
+                    "rain",
+                    0.000,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "weeklyrain": CalculatedDataPoint(
+                    "rain",
+                    0.000,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "monthlyrain": CalculatedDataPoint(
+                    "rain",
+                    0.736,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "yearlyrain": CalculatedDataPoint(
+                    "rain",
+                    3.909,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
                 "rrain_piezo": CalculatedDataPoint(
-                    "rrain", 0.000, unit=f"{RAINFALL_INCHES}/hr"
+                    "rrain",
+                    0.000,
+                    unit=f"{RAINFALL_INCHES}/hr",
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
-                "erain_piezo": CalculatedDataPoint("rain", 0.063, unit=RAINFALL_INCHES),
-                "hrain_piezo": CalculatedDataPoint("rain", 0.000, unit=RAINFALL_INCHES),
-                "drain_piezo": CalculatedDataPoint("rain", 0.075, unit=RAINFALL_INCHES),
-                "wrain_piezo": CalculatedDataPoint("rain", 0.075, unit=RAINFALL_INCHES),
-                "mrain_piezo": CalculatedDataPoint("rain", 0.941, unit=RAINFALL_INCHES),
-                "yrain_piezo": CalculatedDataPoint("rain", 4.114, unit=RAINFALL_INCHES),
+                "erain_piezo": CalculatedDataPoint(
+                    "rain",
+                    0.063,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "hrain_piezo": CalculatedDataPoint(
+                    "rain",
+                    0.000,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "drain_piezo": CalculatedDataPoint(
+                    "rain",
+                    0.075,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "wrain_piezo": CalculatedDataPoint(
+                    "rain",
+                    0.075,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "mrain_piezo": CalculatedDataPoint(
+                    "rain",
+                    0.941,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "yrain_piezo": CalculatedDataPoint(
+                    "rain",
+                    4.114,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
                 "ws90cap_volt": CalculatedDataPoint(
-                    "volt", 5.2, unit=ELECTRIC_POTENTIAL_VOLT
+                    "volt",
+                    5.2,
+                    unit=ELECTRIC_POTENTIAL_VOLT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
-                "temp1": CalculatedDataPoint("temp", 71.2, unit=TEMP_FAHRENHEIT),
-                "humidity1": CalculatedDataPoint("humidity", 61, unit=PERCENTAGE),
-                "temp2": CalculatedDataPoint("temp", 71.2, unit=TEMP_FAHRENHEIT),
-                "humidity2": CalculatedDataPoint("humidity", 58, unit=PERCENTAGE),
-                "temp3": CalculatedDataPoint("temp", 70.5, unit=TEMP_FAHRENHEIT),
-                "humidity3": CalculatedDataPoint("humidity", 61, unit=PERCENTAGE),
-                "temp4": CalculatedDataPoint("temp", 73.0, unit=TEMP_FAHRENHEIT),
-                "humidity4": CalculatedDataPoint("humidity", 58, unit=PERCENTAGE),
-                "temp5": CalculatedDataPoint("temp", 70.7, unit=TEMP_FAHRENHEIT),
-                "humidity5": CalculatedDataPoint("humidity", 69, unit=PERCENTAGE),
-                "temp6": CalculatedDataPoint("temp", 72.7, unit=TEMP_FAHRENHEIT),
-                "humidity6": CalculatedDataPoint("humidity", 58, unit=PERCENTAGE),
-                "temp7": CalculatedDataPoint("temp", 67.1, unit=TEMP_FAHRENHEIT),
-                "humidity7": CalculatedDataPoint("humidity", 54, unit=PERCENTAGE),
-                "temp8": CalculatedDataPoint("temp", 68.0, unit=TEMP_FAHRENHEIT),
-                "humidity8": CalculatedDataPoint("humidity", 56, unit=PERCENTAGE),
-                "soilmoisture1": CalculatedDataPoint("moisture", 53, unit=PERCENTAGE),
-                "soilmoisture2": CalculatedDataPoint("moisture", 57, unit=PERCENTAGE),
-                "soilmoisture3": CalculatedDataPoint("moisture", 59, unit=PERCENTAGE),
-                "soilmoisture4": CalculatedDataPoint("moisture", 49, unit=PERCENTAGE),
-                "soilmoisture5": CalculatedDataPoint("moisture", 52, unit=PERCENTAGE),
+                "temp1": CalculatedDataPoint(
+                    "temp",
+                    71.2,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "humidity1": CalculatedDataPoint(
+                    "humidity", 61, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+                ),
+                "temp2": CalculatedDataPoint(
+                    "temp",
+                    71.2,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "humidity2": CalculatedDataPoint(
+                    "humidity", 58, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+                ),
+                "temp3": CalculatedDataPoint(
+                    "temp",
+                    70.5,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "humidity3": CalculatedDataPoint(
+                    "humidity", 61, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+                ),
+                "temp4": CalculatedDataPoint(
+                    "temp",
+                    73.0,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "humidity4": CalculatedDataPoint(
+                    "humidity", 58, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+                ),
+                "temp5": CalculatedDataPoint(
+                    "temp",
+                    70.7,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "humidity5": CalculatedDataPoint(
+                    "humidity", 69, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+                ),
+                "temp6": CalculatedDataPoint(
+                    "temp",
+                    72.7,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "humidity6": CalculatedDataPoint(
+                    "humidity", 58, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+                ),
+                "temp7": CalculatedDataPoint(
+                    "temp",
+                    67.1,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "humidity7": CalculatedDataPoint(
+                    "humidity", 54, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+                ),
+                "temp8": CalculatedDataPoint(
+                    "temp",
+                    68.0,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "humidity8": CalculatedDataPoint(
+                    "humidity", 56, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+                ),
+                "soilmoisture1": CalculatedDataPoint(
+                    "moisture", 53, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+                ),
+                "soilmoisture2": CalculatedDataPoint(
+                    "moisture", 57, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+                ),
+                "soilmoisture3": CalculatedDataPoint(
+                    "moisture", 59, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+                ),
+                "soilmoisture4": CalculatedDataPoint(
+                    "moisture", 49, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+                ),
+                "soilmoisture5": CalculatedDataPoint(
+                    "moisture", 52, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+                ),
                 "pm25_ch1": CalculatedDataPoint(
-                    "pm25", 21.0, unit=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
+                    "pm25",
+                    21.0,
+                    unit=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "pm25_avg_24h_ch1": CalculatedDataPoint(
-                    "pm25", 16.3, unit=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
+                    "pm25",
+                    16.3,
+                    unit=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
-                "tf_co2": CalculatedDataPoint("tf_co2", 62.2, unit=TEMP_FAHRENHEIT),
-                "humi_co2": CalculatedDataPoint("humi_co2", 61, unit=PERCENTAGE),
+                "tf_co2": CalculatedDataPoint(
+                    "tf_co2",
+                    62.2,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "humi_co2": CalculatedDataPoint(
+                    "humi_co2", 61, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+                ),
                 "pm25_co2": CalculatedDataPoint(
-                    "pm25", 4.9, unit=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
+                    "pm25",
+                    4.9,
+                    unit=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "pm25_24h_co2": CalculatedDataPoint(
-                    "pm25", 7.5, unit=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
+                    "pm25",
+                    7.5,
+                    unit=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "pm10_co2": CalculatedDataPoint(
-                    "pm10", 6.1, unit=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
+                    "pm10",
+                    6.1,
+                    unit=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "pm10_24h_co2": CalculatedDataPoint(
-                    "pm10", 7.8, unit=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
+                    "pm10",
+                    7.8,
+                    unit=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "co2": CalculatedDataPoint(
-                    "co2", 455, unit=CONCENTRATION_PARTS_PER_MILLION
+                    "co2",
+                    455,
+                    unit=CONCENTRATION_PARTS_PER_MILLION,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "co2_24h": CalculatedDataPoint(
-                    "co2_24h", 473, unit=CONCENTRATION_PARTS_PER_MILLION
+                    "co2_24h",
+                    473,
+                    unit=CONCENTRATION_PARTS_PER_MILLION,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
-                "lightning_num": CalculatedDataPoint("lightning_num", 13, unit=STRIKES),
-                "lightning": CalculatedDataPoint("lightning", 0.6, unit=DISTANCE_MILES),
+                "lightning_num": CalculatedDataPoint(
+                    "lightning_num",
+                    13,
+                    unit=STRIKES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "lightning": CalculatedDataPoint(
+                    "lightning",
+                    0.6,
+                    unit=DISTANCE_MILES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
                 "lightning_time": CalculatedDataPoint(
                     "lightning_time",
                     datetime(2022, 4, 20, 17, 17, 17, tzinfo=timezone.utc),
                 ),
                 "wh80batt": CalculatedDataPoint(
-                    "batt", 3.28, unit=ELECTRIC_POTENTIAL_VOLT
+                    "batt",
+                    3.28,
+                    unit=ELECTRIC_POTENTIAL_VOLT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
-                "batt1": CalculatedDataPoint("batt", BooleanBatteryState.OFF),
-                "batt2": CalculatedDataPoint("batt", BooleanBatteryState.OFF),
-                "batt3": CalculatedDataPoint("batt", BooleanBatteryState.OFF),
-                "batt4": CalculatedDataPoint("batt", BooleanBatteryState.OFF),
-                "batt5": CalculatedDataPoint("batt", BooleanBatteryState.OFF),
-                "batt6": CalculatedDataPoint("batt", BooleanBatteryState.OFF),
-                "batt7": CalculatedDataPoint("batt", BooleanBatteryState.OFF),
-                "batt8": CalculatedDataPoint("batt", BooleanBatteryState.OFF),
+                "batt1": CalculatedDataPoint(
+                    "batt",
+                    BooleanBatteryState.OFF,
+                    unit=None,
+                    data_type=DataPointType.BOOLEAN,
+                ),
+                "batt2": CalculatedDataPoint(
+                    "batt",
+                    BooleanBatteryState.OFF,
+                    unit=None,
+                    data_type=DataPointType.BOOLEAN,
+                ),
+                "batt3": CalculatedDataPoint(
+                    "batt",
+                    BooleanBatteryState.OFF,
+                    unit=None,
+                    data_type=DataPointType.BOOLEAN,
+                ),
+                "batt4": CalculatedDataPoint(
+                    "batt",
+                    BooleanBatteryState.OFF,
+                    unit=None,
+                    data_type=DataPointType.BOOLEAN,
+                ),
+                "batt5": CalculatedDataPoint(
+                    "batt",
+                    BooleanBatteryState.OFF,
+                    unit=None,
+                    data_type=DataPointType.BOOLEAN,
+                ),
+                "batt6": CalculatedDataPoint(
+                    "batt",
+                    BooleanBatteryState.OFF,
+                    unit=None,
+                    data_type=DataPointType.BOOLEAN,
+                ),
+                "batt7": CalculatedDataPoint(
+                    "batt",
+                    BooleanBatteryState.OFF,
+                    unit=None,
+                    data_type=DataPointType.BOOLEAN,
+                ),
+                "batt8": CalculatedDataPoint(
+                    "batt",
+                    BooleanBatteryState.OFF,
+                    unit=None,
+                    data_type=DataPointType.BOOLEAN,
+                ),
                 "soilbatt1": CalculatedDataPoint(
-                    "batt", 1.4, unit=ELECTRIC_POTENTIAL_VOLT
+                    "batt",
+                    1.4,
+                    unit=ELECTRIC_POTENTIAL_VOLT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "soilbatt2": CalculatedDataPoint(
-                    "batt", 1.3, unit=ELECTRIC_POTENTIAL_VOLT
+                    "batt",
+                    1.3,
+                    unit=ELECTRIC_POTENTIAL_VOLT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "soilbatt3": CalculatedDataPoint(
-                    "batt", 1.3, unit=ELECTRIC_POTENTIAL_VOLT
+                    "batt",
+                    1.3,
+                    unit=ELECTRIC_POTENTIAL_VOLT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "soilbatt4": CalculatedDataPoint(
-                    "batt", 1.3, unit=ELECTRIC_POTENTIAL_VOLT
+                    "batt",
+                    1.3,
+                    unit=ELECTRIC_POTENTIAL_VOLT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "soilbatt5": CalculatedDataPoint(
-                    "batt", 1.3, unit=ELECTRIC_POTENTIAL_VOLT
+                    "batt",
+                    1.3,
+                    unit=ELECTRIC_POTENTIAL_VOLT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
-                "pm25batt1": CalculatedDataPoint("batt", 60, unit=PERCENTAGE),
-                "wh57batt": CalculatedDataPoint("batt", 60, unit=PERCENTAGE),
-                "co2_batt": CalculatedDataPoint("batt", 120, unit=PERCENTAGE),
+                "pm25batt1": CalculatedDataPoint(
+                    "batt", 60, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+                ),
+                "wh57batt": CalculatedDataPoint(
+                    "batt", 60, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+                ),
+                "co2_batt": CalculatedDataPoint(
+                    "batt", 120, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+                ),
                 "wh90batt": CalculatedDataPoint(
-                    "batt", 3.22, unit=ELECTRIC_POTENTIAL_VOLT
+                    "batt",
+                    3.22,
+                    unit=ELECTRIC_POTENTIAL_VOLT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
-                "dewpoint": CalculatedDataPoint("dewpoint", 47.9, unit=TEMP_FAHRENHEIT),
+                "dewpoint": CalculatedDataPoint(
+                    "dewpoint",
+                    47.9,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
                 "feelslike": CalculatedDataPoint(
-                    "feelslike", 59.7, unit=TEMP_FAHRENHEIT
+                    "feelslike",
+                    59.7,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "heatindex": CalculatedDataPoint(
-                    "heatindex", 58.4, unit=TEMP_FAHRENHEIT
+                    "heatindex",
+                    58.4,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "windchill": CalculatedDataPoint(
-                    "windchill", None, unit=TEMP_FAHRENHEIT
+                    "windchill",
+                    None,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "humidityabs": CalculatedDataPoint(
                     data_point_key="humidityabs",
                     value=0.0,
                     unit=WATER_VAPOR_POUNDS_PER_CUBIC_FOOT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "humidityabsin": CalculatedDataPoint(
                     data_point_key="humidityabsin",
                     value=0.0,
                     unit=WATER_VAPOR_POUNDS_PER_CUBIC_FOOT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "thermalperception": CalculatedDataPoint(
                     data_point_key="thermalperception",
                     value=ThermalPerception.DRY,
                     unit=None,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "frostpoint": CalculatedDataPoint(
-                    data_point_key="frostpoint", value=44.3, unit=TEMP_FAHRENHEIT
+                    data_point_key="frostpoint",
+                    value=44.3,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "frostrisk": CalculatedDataPoint(
-                    data_point_key="frostrisk", value=FrostRisk.NO_RISK, unit=None
+                    data_point_key="frostrisk",
+                    value=FrostRisk.NO_RISK,
+                    unit=None,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "simmerindex": CalculatedDataPoint(
-                    data_point_key="simmerindex", value=None, unit=TEMP_FAHRENHEIT
+                    data_point_key="simmerindex",
+                    value=None,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "simmerzone": CalculatedDataPoint(
-                    data_point_key="simmerzone", value=None, unit=None
+                    data_point_key="simmerzone",
+                    value=None,
+                    unit=None,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
             },
         ),
         (
             "payload_pthp2550pro.json",
             {
-                "tempin": CalculatedDataPoint("temp", 64.4, unit=TEMP_FAHRENHEIT),
-                "humidityin": CalculatedDataPoint("humidity", 72, unit=PERCENTAGE),
-                "baromrel": CalculatedDataPoint("barom", 28.196, unit=PRESSURE_INHG),
-                "baromabs": CalculatedDataPoint("barom", 28.196, unit=PRESSURE_INHG),
-                "temp": CalculatedDataPoint("temp", 35.2, unit=TEMP_FAHRENHEIT),
-                "humidity": CalculatedDataPoint("humidity", 60, unit=PERCENTAGE),
-                "winddir": CalculatedDataPoint("winddir", 289, unit=DEGREE),
-                "winddir_avg10m": CalculatedDataPoint("winddir", 282, unit=DEGREE),
+                "tempin": CalculatedDataPoint(
+                    "temp",
+                    64.4,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "humidityin": CalculatedDataPoint(
+                    "humidity", 72, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+                ),
+                "baromrel": CalculatedDataPoint(
+                    "barom",
+                    28.196,
+                    unit=PRESSURE_INHG,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "baromabs": CalculatedDataPoint(
+                    "barom",
+                    28.196,
+                    unit=PRESSURE_INHG,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "temp": CalculatedDataPoint(
+                    "temp",
+                    35.2,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "humidity": CalculatedDataPoint(
+                    "humidity", 60, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+                ),
+                "winddir": CalculatedDataPoint(
+                    "winddir", 289, unit=DEGREE, data_type=DataPointType.NON_BOOLEAN
+                ),
+                "winddir_avg10m": CalculatedDataPoint(
+                    "winddir", 282, unit=DEGREE, data_type=DataPointType.NON_BOOLEAN
+                ),
                 "windspeed": CalculatedDataPoint(
-                    "wind", 2.7, unit=SPEED_MILES_PER_HOUR
+                    "wind",
+                    2.7,
+                    unit=SPEED_MILES_PER_HOUR,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "windspdmph_avg10m": CalculatedDataPoint(
-                    "wind", 2.5, unit=SPEED_MILES_PER_HOUR
+                    "wind",
+                    2.5,
+                    unit=SPEED_MILES_PER_HOUR,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
-                "windgust": CalculatedDataPoint("gust", 6.9, unit=SPEED_MILES_PER_HOUR),
+                "windgust": CalculatedDataPoint(
+                    "gust",
+                    6.9,
+                    unit=SPEED_MILES_PER_HOUR,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
                 "maxdailygust": CalculatedDataPoint(
-                    "gust", 20.6, unit=SPEED_MILES_PER_HOUR
+                    "gust",
+                    20.6,
+                    unit=SPEED_MILES_PER_HOUR,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "rainrate": CalculatedDataPoint(
-                    "rainrate", 0.000, unit=f"{RAINFALL_INCHES}/hr"
+                    "rainrate",
+                    0.000,
+                    unit=f"{RAINFALL_INCHES}/hr",
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
-                "eventrain": CalculatedDataPoint("rain", 0.134, unit=RAINFALL_INCHES),
-                "hourlyrain": CalculatedDataPoint("rain", 0.012, unit=RAINFALL_INCHES),
-                "dailyrain": CalculatedDataPoint("rain", 0.134, unit=RAINFALL_INCHES),
-                "weeklyrain": CalculatedDataPoint("rain", 0.134, unit=RAINFALL_INCHES),
-                "monthlyrain": CalculatedDataPoint("rain", 1.110, unit=RAINFALL_INCHES),
-                "yearlyrain": CalculatedDataPoint("rain", 11.610, unit=RAINFALL_INCHES),
+                "eventrain": CalculatedDataPoint(
+                    "rain",
+                    0.134,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "hourlyrain": CalculatedDataPoint(
+                    "rain",
+                    0.012,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "dailyrain": CalculatedDataPoint(
+                    "rain",
+                    0.134,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "weeklyrain": CalculatedDataPoint(
+                    "rain",
+                    0.134,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "monthlyrain": CalculatedDataPoint(
+                    "rain",
+                    1.110,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "yearlyrain": CalculatedDataPoint(
+                    "rain",
+                    11.610,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
                 "solarradiation": CalculatedDataPoint(
-                    "solarradiation", 174.81, unit=IRRADIATION_WATTS_PER_SQUARE_METER
+                    "solarradiation",
+                    174.81,
+                    unit=IRRADIATION_WATTS_PER_SQUARE_METER,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "solarradiation_lux": CalculatedDataPoint(
-                    "solarradiation_lux", 22127.8, unit=LIGHT_LUX
+                    "solarradiation_lux",
+                    22127.8,
+                    unit=LIGHT_LUX,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "solarradiation_perceived": CalculatedDataPoint(
-                    "solarradiation_perceived", 87.0, unit=PERCENTAGE
+                    "solarradiation_perceived",
+                    87.0,
+                    unit=PERCENTAGE,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
-                "uv": CalculatedDataPoint("uv", 1, unit=UV_INDEX),
+                "uv": CalculatedDataPoint(
+                    "uv", 1, unit=UV_INDEX, data_type=DataPointType.NON_BOOLEAN
+                ),
                 "safe_exposure_time_skin_type_1": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_1", 166.7, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_1",
+                    166.7,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "safe_exposure_time_skin_type_2": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_2", 200.0, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_2",
+                    200.0,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "safe_exposure_time_skin_type_3": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_3", 266.7, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_3",
+                    266.7,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "safe_exposure_time_skin_type_4": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_4", 333.3, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_4",
+                    333.3,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "safe_exposure_time_skin_type_5": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_5", 533.3, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_5",
+                    533.3,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "safe_exposure_time_skin_type_6": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_6", 866.7, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_6",
+                    866.7,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
-                "temp1": CalculatedDataPoint("temp", 66.4, unit=TEMP_FAHRENHEIT),
-                "humidity1": CalculatedDataPoint("humidity", 69, unit=PERCENTAGE),
-                "soilmoisture1": CalculatedDataPoint("moisture", 22, unit=PERCENTAGE),
+                "temp1": CalculatedDataPoint(
+                    "temp",
+                    66.4,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "humidity1": CalculatedDataPoint(
+                    "humidity", 69, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+                ),
+                "soilmoisture1": CalculatedDataPoint(
+                    "moisture", 22, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+                ),
                 "pm25_ch1": CalculatedDataPoint(
-                    "pm25", 7.0, unit=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
+                    "pm25",
+                    7.0,
+                    unit=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "pm25_avg_24h_ch1": CalculatedDataPoint(
-                    "pm25", 14.3, unit=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
+                    "pm25",
+                    14.3,
+                    unit=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
-                "wh65batt": CalculatedDataPoint("batt", BooleanBatteryState.OFF),
-                "wh25batt": CalculatedDataPoint("batt", BooleanBatteryState.OFF),
-                "batt1": CalculatedDataPoint("batt", BooleanBatteryState.OFF),
+                "wh65batt": CalculatedDataPoint(
+                    "batt",
+                    BooleanBatteryState.OFF,
+                    unit=None,
+                    data_type=DataPointType.BOOLEAN,
+                ),
+                "wh25batt": CalculatedDataPoint(
+                    "batt",
+                    BooleanBatteryState.OFF,
+                    unit=None,
+                    data_type=DataPointType.BOOLEAN,
+                ),
+                "batt1": CalculatedDataPoint(
+                    "batt",
+                    BooleanBatteryState.OFF,
+                    unit=None,
+                    data_type=DataPointType.BOOLEAN,
+                ),
                 "soilbatt1": CalculatedDataPoint(
-                    "batt", 1.5, unit=ELECTRIC_POTENTIAL_VOLT
+                    "batt",
+                    1.5,
+                    unit=ELECTRIC_POTENTIAL_VOLT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
-                "pm25batt1": CalculatedDataPoint("batt", 100, unit=PERCENTAGE),
-                "dewpoint": CalculatedDataPoint("dewpoint", 22.7, unit=TEMP_FAHRENHEIT),
+                "pm25batt1": CalculatedDataPoint(
+                    "batt", 100, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+                ),
+                "dewpoint": CalculatedDataPoint(
+                    "dewpoint",
+                    22.7,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
                 "feelslike": CalculatedDataPoint(
-                    "feelslike", 35.2, unit=TEMP_FAHRENHEIT
+                    "feelslike",
+                    35.2,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "heatindex": CalculatedDataPoint(
-                    "heatindex", 31.2, unit=TEMP_FAHRENHEIT
+                    "heatindex",
+                    31.2,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "windchill": CalculatedDataPoint(
-                    "windchill", None, unit=TEMP_FAHRENHEIT
+                    "windchill",
+                    None,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "humidityabs": CalculatedDataPoint(
                     data_point_key="humidityabs",
                     value=0.0,
                     unit=WATER_VAPOR_POUNDS_PER_CUBIC_FOOT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "humidityabsin": CalculatedDataPoint(
                     data_point_key="humidityabsin",
                     value=0.0,
                     unit=WATER_VAPOR_POUNDS_PER_CUBIC_FOOT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "thermalperception": CalculatedDataPoint(
                     data_point_key="thermalperception",
                     value=ThermalPerception.DRY,
                     unit=None,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "frostpoint": CalculatedDataPoint(
-                    data_point_key="frostpoint", value=22.4, unit=TEMP_FAHRENHEIT
+                    data_point_key="frostpoint",
+                    value=22.4,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "frostrisk": CalculatedDataPoint(
-                    data_point_key="frostrisk", value=FrostRisk.PROBABLE, unit=None
+                    data_point_key="frostrisk",
+                    value=FrostRisk.PROBABLE,
+                    unit=None,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "simmerindex": CalculatedDataPoint(
-                    data_point_key="simmerindex", value=None, unit=TEMP_FAHRENHEIT
+                    data_point_key="simmerindex",
+                    value=None,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "simmerzone": CalculatedDataPoint(
-                    data_point_key="simmerzone", value=None, unit=None
+                    data_point_key="simmerzone",
+                    value=None,
+                    unit=None,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
             },
         ),
         (
             "payload_wh2650a.json",
             {
-                "runtime": CalculatedDataPoint("runtime", 49030, unit=TIME_SECONDS),
-                "tempin": CalculatedDataPoint("temp", 71.2, unit=TEMP_FAHRENHEIT),
-                "humidityin": CalculatedDataPoint("humidity", 60, unit=PERCENTAGE),
-                "baromrel": CalculatedDataPoint("barom", 32.211, unit=PRESSURE_INHG),
-                "baromabs": CalculatedDataPoint("barom", 29.648, unit=PRESSURE_INHG),
-                "temp": CalculatedDataPoint("temp", 76.3, unit=TEMP_FAHRENHEIT),
-                "humidity": CalculatedDataPoint("humidity", 54, unit=PERCENTAGE),
-                "winddir": CalculatedDataPoint("winddir", 217, unit=DEGREE),
+                "runtime": CalculatedDataPoint(
+                    "runtime",
+                    49030,
+                    unit=TIME_SECONDS,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "tempin": CalculatedDataPoint(
+                    "temp",
+                    71.2,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "humidityin": CalculatedDataPoint(
+                    "humidity", 60, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+                ),
+                "baromrel": CalculatedDataPoint(
+                    "barom",
+                    32.211,
+                    unit=PRESSURE_INHG,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "baromabs": CalculatedDataPoint(
+                    "barom",
+                    29.648,
+                    unit=PRESSURE_INHG,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "temp": CalculatedDataPoint(
+                    "temp",
+                    76.3,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "humidity": CalculatedDataPoint(
+                    "humidity", 54, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+                ),
+                "winddir": CalculatedDataPoint(
+                    "winddir", 217, unit=DEGREE, data_type=DataPointType.NON_BOOLEAN
+                ),
                 "windspeed": CalculatedDataPoint(
-                    "wind", 1.12, unit=SPEED_MILES_PER_HOUR
+                    "wind",
+                    1.12,
+                    unit=SPEED_MILES_PER_HOUR,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "windgust": CalculatedDataPoint(
-                    "gust", 2.24, unit=SPEED_MILES_PER_HOUR
+                    "gust",
+                    2.24,
+                    unit=SPEED_MILES_PER_HOUR,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "maxdailygust": CalculatedDataPoint(
-                    "gust", 10.07, unit=SPEED_MILES_PER_HOUR
+                    "gust",
+                    10.07,
+                    unit=SPEED_MILES_PER_HOUR,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "solarradiation": CalculatedDataPoint(
-                    "solarradiation", 642.38, unit=IRRADIATION_WATTS_PER_SQUARE_METER
+                    "solarradiation",
+                    642.38,
+                    unit=IRRADIATION_WATTS_PER_SQUARE_METER,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "solarradiation_lux": CalculatedDataPoint(
-                    "solarradiation_lux", 81313.9, unit=LIGHT_LUX
+                    "solarradiation_lux",
+                    81313.9,
+                    unit=LIGHT_LUX,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "solarradiation_perceived": CalculatedDataPoint(
-                    "solarradiation_perceived", 98.0, unit=PERCENTAGE
+                    "solarradiation_perceived",
+                    98.0,
+                    unit=PERCENTAGE,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
-                "uv": CalculatedDataPoint("uv", 6, unit=UV_INDEX),
+                "uv": CalculatedDataPoint(
+                    "uv", 6, unit=UV_INDEX, data_type=DataPointType.NON_BOOLEAN
+                ),
                 "safe_exposure_time_skin_type_1": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_1", 27.8, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_1",
+                    27.8,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "safe_exposure_time_skin_type_2": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_2", 33.3, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_2",
+                    33.3,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "safe_exposure_time_skin_type_3": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_3", 44.4, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_3",
+                    44.4,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "safe_exposure_time_skin_type_4": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_4", 55.6, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_4",
+                    55.6,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "safe_exposure_time_skin_type_5": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_5", 88.9, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_5",
+                    88.9,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "safe_exposure_time_skin_type_6": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_6", 144.4, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_6",
+                    144.4,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "rainrate": CalculatedDataPoint(
-                    "rainrate", 0.000, unit=f"{RAINFALL_INCHES}/hr"
+                    "rainrate",
+                    0.000,
+                    unit=f"{RAINFALL_INCHES}/hr",
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
-                "eventrain": CalculatedDataPoint("rain", 0.000, unit=RAINFALL_INCHES),
-                "hourlyrain": CalculatedDataPoint("rain", 0.000, unit=RAINFALL_INCHES),
-                "dailyrain": CalculatedDataPoint("rain", 0.000, unit=RAINFALL_INCHES),
-                "weeklyrain": CalculatedDataPoint("rain", 0.000, unit=RAINFALL_INCHES),
-                "monthlyrain": CalculatedDataPoint("rain", 0.000, unit=RAINFALL_INCHES),
-                "yearlyrain": CalculatedDataPoint("rain", 0.000, unit=RAINFALL_INCHES),
+                "eventrain": CalculatedDataPoint(
+                    "rain",
+                    0.000,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "hourlyrain": CalculatedDataPoint(
+                    "rain",
+                    0.000,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "dailyrain": CalculatedDataPoint(
+                    "rain",
+                    0.000,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "weeklyrain": CalculatedDataPoint(
+                    "rain",
+                    0.000,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "monthlyrain": CalculatedDataPoint(
+                    "rain",
+                    0.000,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "yearlyrain": CalculatedDataPoint(
+                    "rain",
+                    0.000,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
                 "totalain": CalculatedDataPoint(
-                    "totalain", 0.000, unit=RAINFALL_INCHES
+                    "totalain",
+                    0.000,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "wh65batt": CalculatedDataPoint(
-                    "batt", BooleanBatteryState.OFF, unit=None
+                    "batt",
+                    BooleanBatteryState.OFF,
+                    unit=None,
+                    data_type=DataPointType.BOOLEAN,
                 ),
                 "wh25batt": CalculatedDataPoint(
-                    "batt", BooleanBatteryState.ON, unit=None
+                    "batt",
+                    BooleanBatteryState.ON,
+                    unit=None,
+                    data_type=DataPointType.BOOLEAN,
                 ),
-                "dewpoint": CalculatedDataPoint("dewpoint", 58.4, unit=TEMP_FAHRENHEIT),
+                "dewpoint": CalculatedDataPoint(
+                    "dewpoint",
+                    58.4,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
                 "feelslike": CalculatedDataPoint(
-                    "feelslike", 76.3, unit=TEMP_FAHRENHEIT
+                    "feelslike",
+                    76.3,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "heatindex": CalculatedDataPoint(
-                    "heatindex", 76.1, unit=TEMP_FAHRENHEIT
+                    "heatindex",
+                    76.1,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "windchill": CalculatedDataPoint(
-                    "windchill", None, unit=TEMP_FAHRENHEIT
+                    "windchill",
+                    None,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "humidityabs": CalculatedDataPoint(
                     data_point_key="humidityabs",
                     value=0.0,
                     unit=WATER_VAPOR_POUNDS_PER_CUBIC_FOOT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "humidityabsin": CalculatedDataPoint(
                     data_point_key="humidityabsin",
                     value=0.0,
                     unit=WATER_VAPOR_POUNDS_PER_CUBIC_FOOT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "thermalperception": CalculatedDataPoint(
                     data_point_key="thermalperception",
                     value=ThermalPerception.COMFORTABLE,
                     unit=None,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "frostpoint": CalculatedDataPoint(
-                    data_point_key="frostpoint", value=52.3, unit=TEMP_FAHRENHEIT
+                    data_point_key="frostpoint",
+                    value=52.3,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "frostrisk": CalculatedDataPoint(
-                    data_point_key="frostrisk", value=FrostRisk.NO_RISK, unit=None
+                    data_point_key="frostrisk",
+                    value=FrostRisk.NO_RISK,
+                    unit=None,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "simmerindex": CalculatedDataPoint(
-                    data_point_key="simmerindex", value=85.0, unit=TEMP_FAHRENHEIT
+                    data_point_key="simmerindex",
+                    value=85.0,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "simmerzone": CalculatedDataPoint(
                     data_point_key="simmerzone",
                     value=SimmerZone.SLIGHTLY_WARM,
                     unit=None,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
             },
         ),
         (
             "payload_ws2900.json",
             {
-                "tempin": CalculatedDataPoint("temp", 72.9, unit=TEMP_FAHRENHEIT),
-                "humidityin": CalculatedDataPoint("humidity", 62, unit=PERCENTAGE),
-                "baromrel": CalculatedDataPoint("barom", 29.829, unit=PRESSURE_INHG),
-                "baromabs": CalculatedDataPoint("barom", 28.122, unit=PRESSURE_INHG),
-                "temp": CalculatedDataPoint("temp", 22.0, unit=TEMP_FAHRENHEIT),
-                "humidity": CalculatedDataPoint("humidity", 100, unit=PERCENTAGE),
-                "winddir": CalculatedDataPoint("winddir", 271, unit=DEGREE),
-                "windspeed": CalculatedDataPoint(
-                    "wind", 6.9, unit=SPEED_MILES_PER_HOUR
+                "tempin": CalculatedDataPoint(
+                    "temp",
+                    72.9,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
-                "windgust": CalculatedDataPoint("gust", 9.2, unit=SPEED_MILES_PER_HOUR),
+                "humidityin": CalculatedDataPoint(
+                    "humidity", 62, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+                ),
+                "baromrel": CalculatedDataPoint(
+                    "barom",
+                    29.829,
+                    unit=PRESSURE_INHG,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "baromabs": CalculatedDataPoint(
+                    "barom",
+                    28.122,
+                    unit=PRESSURE_INHG,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "temp": CalculatedDataPoint(
+                    "temp",
+                    22.0,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "humidity": CalculatedDataPoint(
+                    "humidity",
+                    100,
+                    unit=PERCENTAGE,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "winddir": CalculatedDataPoint(
+                    "winddir", 271, unit=DEGREE, data_type=DataPointType.NON_BOOLEAN
+                ),
+                "windspeed": CalculatedDataPoint(
+                    "wind",
+                    6.9,
+                    unit=SPEED_MILES_PER_HOUR,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "windgust": CalculatedDataPoint(
+                    "gust",
+                    9.2,
+                    unit=SPEED_MILES_PER_HOUR,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
                 "maxdailygust": CalculatedDataPoint(
-                    "gust", 9.2, unit=SPEED_MILES_PER_HOUR
+                    "gust",
+                    9.2,
+                    unit=SPEED_MILES_PER_HOUR,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "rainrate": CalculatedDataPoint(
-                    "rainrate", 0.000, unit=f"{RAINFALL_INCHES}/hr"
+                    "rainrate",
+                    0.000,
+                    unit=f"{RAINFALL_INCHES}/hr",
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
-                "eventrain": CalculatedDataPoint("rain", 1.331, unit=RAINFALL_INCHES),
-                "hourlyrain": CalculatedDataPoint("rain", 0.000, unit=RAINFALL_INCHES),
-                "dailyrain": CalculatedDataPoint("rain", 0.000, unit=RAINFALL_INCHES),
-                "weeklyrain": CalculatedDataPoint("rain", 1.331, unit=RAINFALL_INCHES),
-                "monthlyrain": CalculatedDataPoint("rain", 4.929, unit=RAINFALL_INCHES),
-                "totalrain": CalculatedDataPoint("rain", 14.890, unit=RAINFALL_INCHES),
+                "eventrain": CalculatedDataPoint(
+                    "rain",
+                    1.331,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "hourlyrain": CalculatedDataPoint(
+                    "rain",
+                    0.000,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "dailyrain": CalculatedDataPoint(
+                    "rain",
+                    0.000,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "weeklyrain": CalculatedDataPoint(
+                    "rain",
+                    1.331,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "monthlyrain": CalculatedDataPoint(
+                    "rain",
+                    4.929,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "totalrain": CalculatedDataPoint(
+                    "rain",
+                    14.890,
+                    unit=RAINFALL_INCHES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
                 "solarradiation": CalculatedDataPoint(
-                    "solarradiation", 0.00, unit=IRRADIATION_WATTS_PER_SQUARE_METER
+                    "solarradiation",
+                    0.00,
+                    unit=IRRADIATION_WATTS_PER_SQUARE_METER,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "solarradiation_lux": CalculatedDataPoint(
-                    "solarradiation_lux", 0.0, unit=LIGHT_LUX
+                    "solarradiation_lux",
+                    0.0,
+                    unit=LIGHT_LUX,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "solarradiation_perceived": CalculatedDataPoint(
-                    "solarradiation_perceived", 0.0, unit=PERCENTAGE
+                    "solarradiation_perceived",
+                    0.0,
+                    unit=PERCENTAGE,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
-                "uv": CalculatedDataPoint("uv", 0, unit=UV_INDEX),
+                "uv": CalculatedDataPoint(
+                    "uv", 0, unit=UV_INDEX, data_type=DataPointType.NON_BOOLEAN
+                ),
                 "safe_exposure_time_skin_type_1": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_1", None, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_1",
+                    None,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "safe_exposure_time_skin_type_2": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_2", None, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_2",
+                    None,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "safe_exposure_time_skin_type_3": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_3", None, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_3",
+                    None,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "safe_exposure_time_skin_type_4": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_4", None, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_4",
+                    None,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "safe_exposure_time_skin_type_5": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_5", None, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_5",
+                    None,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "safe_exposure_time_skin_type_6": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_6", None, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_6",
+                    None,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
-                "wh65batt": CalculatedDataPoint("batt", BooleanBatteryState.OFF),
-                "dewpoint": CalculatedDataPoint("dewpoint", 22.0, unit=TEMP_FAHRENHEIT),
+                "wh65batt": CalculatedDataPoint(
+                    "batt",
+                    BooleanBatteryState.OFF,
+                    unit=None,
+                    data_type=DataPointType.BOOLEAN,
+                ),
+                "dewpoint": CalculatedDataPoint(
+                    "dewpoint",
+                    22.0,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
                 "feelslike": CalculatedDataPoint(
-                    "feelslike", 13.5, unit=TEMP_FAHRENHEIT
+                    "feelslike",
+                    13.5,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "heatindex": CalculatedDataPoint(
-                    "heatindex", 18.6, unit=TEMP_FAHRENHEIT
+                    "heatindex",
+                    18.6,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "windchill": CalculatedDataPoint(
-                    "windchill", 13.5, unit=TEMP_FAHRENHEIT
+                    "windchill",
+                    13.5,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "humidityabs": CalculatedDataPoint(
                     data_point_key="humidityabs",
                     value=0.0,
                     unit=WATER_VAPOR_POUNDS_PER_CUBIC_FOOT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "humidityabsin": CalculatedDataPoint(
                     data_point_key="humidityabsin",
                     value=0.0,
                     unit=WATER_VAPOR_POUNDS_PER_CUBIC_FOOT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "thermalperception": CalculatedDataPoint(
                     data_point_key="thermalperception",
                     value=ThermalPerception.DRY,
                     unit=None,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "frostpoint": CalculatedDataPoint(
-                    data_point_key="frostpoint", value=23.1, unit=TEMP_FAHRENHEIT
+                    data_point_key="frostpoint",
+                    value=23.1,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "frostrisk": CalculatedDataPoint(
-                    data_point_key="frostrisk", value=FrostRisk.VERY_PROBABLE, unit=None
+                    data_point_key="frostrisk",
+                    value=FrostRisk.VERY_PROBABLE,
+                    unit=None,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "simmerindex": CalculatedDataPoint(
-                    data_point_key="simmerindex", value=None, unit=TEMP_FAHRENHEIT
+                    data_point_key="simmerindex",
+                    value=None,
+                    unit=TEMP_FAHRENHEIT,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "simmerzone": CalculatedDataPoint(
-                    data_point_key="simmerzone", value=None, unit=None
+                    data_point_key="simmerzone",
+                    value=None,
+                    unit=None,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
             },
         ),
@@ -1390,88 +3198,185 @@ def test_unit_conversion_to_imperial(device_data, ecowitt):
     """Test conversion between units."""
     processed_data = ProcessedData(ecowitt, device_data)
     assert processed_data.output == {
-        "runtime": CalculatedDataPoint("runtime", 319206, unit=TIME_SECONDS),
-        "tempin": CalculatedDataPoint("temp", 79.5, unit=TEMP_FAHRENHEIT),
-        "humidityin": CalculatedDataPoint("humidity", 31, unit=PERCENTAGE),
-        "baromrel": CalculatedDataPoint("barom", 24.74, unit=PRESSURE_INHG),
-        "baromabs": CalculatedDataPoint("barom", 24.74, unit=PRESSURE_INHG),
-        "temp": CalculatedDataPoint("temp", 24.1, unit=TEMP_FAHRENHEIT),
-        "humidity": CalculatedDataPoint("humidity", 74, unit=PERCENTAGE),
-        "winddir": CalculatedDataPoint("winddir", 139, unit=DEGREE),
-        "windspeed": CalculatedDataPoint("wind", 20.1, unit=SPEED_MILES_PER_HOUR),
-        "windgust": CalculatedDataPoint("gust", 1.1, unit=SPEED_MILES_PER_HOUR),
-        "maxdailygust": CalculatedDataPoint("gust", 8.1, unit=SPEED_MILES_PER_HOUR),
+        "runtime": CalculatedDataPoint(
+            "runtime", 319206, unit=TIME_SECONDS, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "tempin": CalculatedDataPoint(
+            "temp", 79.5, unit=TEMP_FAHRENHEIT, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "humidityin": CalculatedDataPoint(
+            "humidity", 31, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "baromrel": CalculatedDataPoint(
+            "barom", 24.74, unit=PRESSURE_INHG, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "baromabs": CalculatedDataPoint(
+            "barom", 24.74, unit=PRESSURE_INHG, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "temp": CalculatedDataPoint(
+            "temp", 24.1, unit=TEMP_FAHRENHEIT, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "humidity": CalculatedDataPoint(
+            "humidity", 74, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "winddir": CalculatedDataPoint(
+            "winddir", 139, unit=DEGREE, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "windspeed": CalculatedDataPoint(
+            "wind", 20.1, unit=SPEED_MILES_PER_HOUR, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "windgust": CalculatedDataPoint(
+            "gust", 1.1, unit=SPEED_MILES_PER_HOUR, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "maxdailygust": CalculatedDataPoint(
+            "gust", 8.1, unit=SPEED_MILES_PER_HOUR, data_type=DataPointType.NON_BOOLEAN
+        ),
         "solarradiation": CalculatedDataPoint(
-            "solarradiation", 264.61, unit=IRRADIATION_WATTS_PER_SQUARE_METER
+            "solarradiation",
+            264.61,
+            unit=IRRADIATION_WATTS_PER_SQUARE_METER,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "solarradiation_lux": CalculatedDataPoint(
-            "solarradiation_lux", 33494.9, unit=LIGHT_LUX
+            "solarradiation_lux",
+            33494.9,
+            unit=LIGHT_LUX,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "solarradiation_perceived": CalculatedDataPoint(
-            "solarradiation_perceived", 90.0, unit=PERCENTAGE
+            "solarradiation_perceived",
+            90.0,
+            unit=PERCENTAGE,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
-        "uv": CalculatedDataPoint("uv", 2.0, unit=UV_INDEX),
+        "uv": CalculatedDataPoint(
+            "uv", 2.0, unit=UV_INDEX, data_type=DataPointType.NON_BOOLEAN
+        ),
         "safe_exposure_time_skin_type_1": CalculatedDataPoint(
-            "safe_exposure_time_skin_type_1", 83.3, unit=TIME_MINUTES
+            "safe_exposure_time_skin_type_1",
+            83.3,
+            unit=TIME_MINUTES,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "safe_exposure_time_skin_type_2": CalculatedDataPoint(
-            "safe_exposure_time_skin_type_2", 100.0, unit=TIME_MINUTES
+            "safe_exposure_time_skin_type_2",
+            100.0,
+            unit=TIME_MINUTES,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "safe_exposure_time_skin_type_3": CalculatedDataPoint(
-            "safe_exposure_time_skin_type_3", 133.3, unit=TIME_MINUTES
+            "safe_exposure_time_skin_type_3",
+            133.3,
+            unit=TIME_MINUTES,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "safe_exposure_time_skin_type_4": CalculatedDataPoint(
-            "safe_exposure_time_skin_type_4", 166.7, unit=TIME_MINUTES
+            "safe_exposure_time_skin_type_4",
+            166.7,
+            unit=TIME_MINUTES,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "safe_exposure_time_skin_type_5": CalculatedDataPoint(
-            "safe_exposure_time_skin_type_5", 266.7, unit=TIME_MINUTES
+            "safe_exposure_time_skin_type_5",
+            266.7,
+            unit=TIME_MINUTES,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "safe_exposure_time_skin_type_6": CalculatedDataPoint(
-            "safe_exposure_time_skin_type_6", 433.3, unit=TIME_MINUTES
+            "safe_exposure_time_skin_type_6",
+            433.3,
+            unit=TIME_MINUTES,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "rainrate": CalculatedDataPoint(
-            "rainrate", 0.000, unit=f"{RAINFALL_INCHES}/hr"
+            "rainrate",
+            0.000,
+            unit=f"{RAINFALL_INCHES}/hr",
+            data_type=DataPointType.NON_BOOLEAN,
         ),
-        "eventrain": CalculatedDataPoint("rain", 0.000, unit=RAINFALL_INCHES),
-        "hourlyrain": CalculatedDataPoint("rain", 0.000, unit=RAINFALL_INCHES),
-        "dailyrain": CalculatedDataPoint("rain", 0.000, unit=RAINFALL_INCHES),
-        "weeklyrain": CalculatedDataPoint("rain", 0.000, unit=RAINFALL_INCHES),
-        "monthlyrain": CalculatedDataPoint("rain", 2.2, unit=RAINFALL_INCHES),
-        "yearlyrain": CalculatedDataPoint("rain", 4.4, unit=RAINFALL_INCHES),
-        "lightning_num": CalculatedDataPoint("lightning_num", 13, unit=STRIKES),
-        "lightning": CalculatedDataPoint("lightning", 0.6, unit=DISTANCE_MILES),
+        "eventrain": CalculatedDataPoint(
+            "rain", 0.000, unit=RAINFALL_INCHES, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "hourlyrain": CalculatedDataPoint(
+            "rain", 0.000, unit=RAINFALL_INCHES, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "dailyrain": CalculatedDataPoint(
+            "rain", 0.000, unit=RAINFALL_INCHES, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "weeklyrain": CalculatedDataPoint(
+            "rain", 0.000, unit=RAINFALL_INCHES, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "monthlyrain": CalculatedDataPoint(
+            "rain", 2.2, unit=RAINFALL_INCHES, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "yearlyrain": CalculatedDataPoint(
+            "rain", 4.4, unit=RAINFALL_INCHES, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "lightning_num": CalculatedDataPoint(
+            "lightning_num", 13, unit=STRIKES, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "lightning": CalculatedDataPoint(
+            "lightning", 0.6, unit=DISTANCE_MILES, data_type=DataPointType.NON_BOOLEAN
+        ),
         "lightning_time": CalculatedDataPoint(
             "lightning_time", datetime(2022, 4, 20, 17, 17, 17, tzinfo=timezone.utc)
         ),
-        "wh65batt": CalculatedDataPoint("batt", BooleanBatteryState.OFF),
-        "dewpoint": CalculatedDataPoint("dewpoint", 17.0, unit=TEMP_FAHRENHEIT),
-        "feelslike": CalculatedDataPoint("feelslike", 6.3, unit=TEMP_FAHRENHEIT),
-        "heatindex": CalculatedDataPoint("heatindex", 19.7, unit=TEMP_FAHRENHEIT),
-        "windchill": CalculatedDataPoint("windchill", 6.3, unit=TEMP_FAHRENHEIT),
+        "wh65batt": CalculatedDataPoint(
+            "batt", BooleanBatteryState.OFF, unit=None, data_type=DataPointType.BOOLEAN
+        ),
+        "dewpoint": CalculatedDataPoint(
+            "dewpoint", 17.0, unit=TEMP_FAHRENHEIT, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "feelslike": CalculatedDataPoint(
+            "feelslike", 6.3, unit=TEMP_FAHRENHEIT, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "heatindex": CalculatedDataPoint(
+            "heatindex", 19.7, unit=TEMP_FAHRENHEIT, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "windchill": CalculatedDataPoint(
+            "windchill", 6.3, unit=TEMP_FAHRENHEIT, data_type=DataPointType.NON_BOOLEAN
+        ),
         "humidityabs": CalculatedDataPoint(
             data_point_key="humidityabs",
             value=0.0,
             unit=WATER_VAPOR_POUNDS_PER_CUBIC_FOOT,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "humidityabsin": CalculatedDataPoint(
             data_point_key="humidityabsin",
             value=0.0,
             unit=WATER_VAPOR_POUNDS_PER_CUBIC_FOOT,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "thermalperception": CalculatedDataPoint(
-            data_point_key="thermalperception", value=ThermalPerception.DRY, unit=None
+            data_point_key="thermalperception",
+            value=ThermalPerception.DRY,
+            unit=None,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "frostpoint": CalculatedDataPoint(
-            data_point_key="frostpoint", value=17.9, unit=TEMP_FAHRENHEIT
+            data_point_key="frostpoint",
+            value=17.9,
+            unit=TEMP_FAHRENHEIT,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "frostrisk": CalculatedDataPoint(
-            data_point_key="frostrisk", value=FrostRisk.UNLIKELY, unit=None
+            data_point_key="frostrisk",
+            value=FrostRisk.UNLIKELY,
+            unit=None,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "simmerindex": CalculatedDataPoint(
-            data_point_key="simmerindex", value=None, unit=TEMP_FAHRENHEIT
+            data_point_key="simmerindex",
+            value=None,
+            unit=TEMP_FAHRENHEIT,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "simmerzone": CalculatedDataPoint(
-            data_point_key="simmerzone", value=None, unit=None
+            data_point_key="simmerzone",
+            value=None,
+            unit=None,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
     }
 
@@ -1504,218 +3409,473 @@ def test_unit_conversion_to_imperial(device_data, ecowitt):
         (
             "payload_gw1000bpro.json",
             {
-                "runtime": CalculatedDataPoint("runtime", 319206.0, unit=TIME_SECONDS),
-                "tempin": CalculatedDataPoint("temp", 26.4, unit=TEMP_CELSIUS),
-                "humidityin": CalculatedDataPoint("humidity", 31.0, unit=PERCENTAGE),
-                "baromrel": CalculatedDataPoint("barom", 837.793, unit=PRESSURE_HPA),
-                "baromabs": CalculatedDataPoint("barom", 837.793, unit=PRESSURE_HPA),
-                "temp": CalculatedDataPoint("temp", 34.0, unit=TEMP_CELSIUS),
-                "humidity": CalculatedDataPoint("humidity", 64, unit=PERCENTAGE),
-                "winddir": CalculatedDataPoint("winddir", 139.0, unit=DEGREE),
+                "runtime": CalculatedDataPoint(
+                    "runtime",
+                    319206.0,
+                    unit=TIME_SECONDS,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "tempin": CalculatedDataPoint(
+                    "temp", 26.4, unit=TEMP_CELSIUS, data_type=DataPointType.NON_BOOLEAN
+                ),
+                "humidityin": CalculatedDataPoint(
+                    "humidity",
+                    31.0,
+                    unit=PERCENTAGE,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "baromrel": CalculatedDataPoint(
+                    "barom",
+                    837.793,
+                    unit=PRESSURE_HPA,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "baromabs": CalculatedDataPoint(
+                    "barom",
+                    837.793,
+                    unit=PRESSURE_HPA,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "temp": CalculatedDataPoint(
+                    "temp", 34.0, unit=TEMP_CELSIUS, data_type=DataPointType.NON_BOOLEAN
+                ),
+                "humidity": CalculatedDataPoint(
+                    "humidity", 64, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+                ),
+                "winddir": CalculatedDataPoint(
+                    "winddir", 139.0, unit=DEGREE, data_type=DataPointType.NON_BOOLEAN
+                ),
                 "windspeed": CalculatedDataPoint(
-                    "wind", 33.6, unit=SPEED_KILOMETERS_PER_HOUR
+                    "wind",
+                    33.6,
+                    unit=SPEED_KILOMETERS_PER_HOUR,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "windgust": CalculatedDataPoint(
-                    "gust", 1.8, unit=SPEED_KILOMETERS_PER_HOUR
+                    "gust",
+                    1.8,
+                    unit=SPEED_KILOMETERS_PER_HOUR,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "maxdailygust": CalculatedDataPoint(
-                    "gust", 13.0, unit=SPEED_KILOMETERS_PER_HOUR
+                    "gust",
+                    13.0,
+                    unit=SPEED_KILOMETERS_PER_HOUR,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "solarradiation": CalculatedDataPoint(
-                    "solarradiation", 264.61, unit=IRRADIATION_WATTS_PER_SQUARE_METER
+                    "solarradiation",
+                    264.61,
+                    unit=IRRADIATION_WATTS_PER_SQUARE_METER,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "solarradiation_lux": CalculatedDataPoint(
-                    "solarradiation_lux", 33494.9, unit=LIGHT_LUX
+                    "solarradiation_lux",
+                    33494.9,
+                    unit=LIGHT_LUX,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "solarradiation_perceived": CalculatedDataPoint(
-                    "solarradiation_perceived", 90.0, unit=PERCENTAGE
+                    "solarradiation_perceived",
+                    90.0,
+                    unit=PERCENTAGE,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
-                "uv": CalculatedDataPoint("uv", 2.0, unit=UV_INDEX),
+                "uv": CalculatedDataPoint(
+                    "uv", 2.0, unit=UV_INDEX, data_type=DataPointType.NON_BOOLEAN
+                ),
                 "safe_exposure_time_skin_type_1": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_1", 83.3, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_1",
+                    83.3,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "safe_exposure_time_skin_type_2": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_2", 100.0, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_2",
+                    100.0,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "safe_exposure_time_skin_type_3": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_3", 133.3, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_3",
+                    133.3,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "safe_exposure_time_skin_type_4": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_4", 166.7, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_4",
+                    166.7,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "safe_exposure_time_skin_type_5": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_5", 266.7, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_5",
+                    266.7,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "safe_exposure_time_skin_type_6": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_6", 433.3, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_6",
+                    433.3,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "rainrate": CalculatedDataPoint(
-                    "rainrate", 0.0, unit=f"{RAINFALL_MILLIMETERS}/hr"
+                    "rainrate",
+                    0.0,
+                    unit=f"{RAINFALL_MILLIMETERS}/hr",
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "eventrain": CalculatedDataPoint(
-                    "rain", 0.0, unit=RAINFALL_MILLIMETERS
+                    "rain",
+                    0.0,
+                    unit=RAINFALL_MILLIMETERS,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "hourlyrain": CalculatedDataPoint(
-                    "rain", 0.0, unit=RAINFALL_MILLIMETERS
+                    "rain",
+                    0.0,
+                    unit=RAINFALL_MILLIMETERS,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "dailyrain": CalculatedDataPoint(
-                    "rain", 0.0, unit=RAINFALL_MILLIMETERS
+                    "rain",
+                    0.0,
+                    unit=RAINFALL_MILLIMETERS,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "weeklyrain": CalculatedDataPoint(
-                    "rain", 0.0, unit=RAINFALL_MILLIMETERS
+                    "rain",
+                    0.0,
+                    unit=RAINFALL_MILLIMETERS,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "monthlyrain": CalculatedDataPoint(
-                    "rain", 55.3, unit=RAINFALL_MILLIMETERS
+                    "rain",
+                    55.3,
+                    unit=RAINFALL_MILLIMETERS,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "yearlyrain": CalculatedDataPoint(
-                    "rain", 112.8, unit=RAINFALL_MILLIMETERS
+                    "rain",
+                    112.8,
+                    unit=RAINFALL_MILLIMETERS,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
-                "lightning_num": CalculatedDataPoint("lightning_num", 13, unit=STRIKES),
+                "lightning_num": CalculatedDataPoint(
+                    "lightning_num",
+                    13,
+                    unit=STRIKES,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
                 "lightning": CalculatedDataPoint(
-                    "lightning", 1.0, unit=DISTANCE_KILOMETERS
+                    "lightning",
+                    1.0,
+                    unit=DISTANCE_KILOMETERS,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "lightning_time": CalculatedDataPoint(
                     "lightning_time",
                     datetime(2022, 4, 20, 17, 17, 17, tzinfo=timezone.utc),
                 ),
-                "wh65batt": CalculatedDataPoint("batt", BooleanBatteryState.OFF),
-                "dewpoint": CalculatedDataPoint("dewpoint", 26.2, unit=TEMP_CELSIUS),
-                "feelslike": CalculatedDataPoint("feelslike", 43.9, unit=TEMP_CELSIUS),
-                "heatindex": CalculatedDataPoint("heatindex", 43.9, unit=TEMP_CELSIUS),
-                "windchill": CalculatedDataPoint("windchill", None, unit=TEMP_CELSIUS),
+                "wh65batt": CalculatedDataPoint(
+                    "batt",
+                    BooleanBatteryState.OFF,
+                    unit=None,
+                    data_type=DataPointType.BOOLEAN,
+                ),
+                "dewpoint": CalculatedDataPoint(
+                    "dewpoint",
+                    26.2,
+                    unit=TEMP_CELSIUS,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "feelslike": CalculatedDataPoint(
+                    "feelslike",
+                    43.9,
+                    unit=TEMP_CELSIUS,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "heatindex": CalculatedDataPoint(
+                    "heatindex",
+                    43.9,
+                    unit=TEMP_CELSIUS,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "windchill": CalculatedDataPoint(
+                    "windchill",
+                    None,
+                    unit=TEMP_CELSIUS,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
                 "humidityabs": CalculatedDataPoint(
                     data_point_key="humidityabs",
                     value=24.1,
                     unit=WATER_VAPOR_GRAMS_PER_CUBIC_METER,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "humidityabsin": CalculatedDataPoint(
                     data_point_key="humidityabsin",
                     value=15.9,
                     unit=WATER_VAPOR_GRAMS_PER_CUBIC_METER,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "thermalperception": CalculatedDataPoint(
                     data_point_key="thermalperception",
                     value=ThermalPerception.SEVERELY_HIGH,
                     unit=None,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "frostpoint": CalculatedDataPoint(
-                    data_point_key="frostpoint", value=21.3, unit=TEMP_CELSIUS
+                    data_point_key="frostpoint",
+                    value=21.3,
+                    unit=TEMP_CELSIUS,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "frostrisk": CalculatedDataPoint(
-                    data_point_key="frostrisk", value=FrostRisk.NO_RISK, unit=None
+                    data_point_key="frostrisk",
+                    value=FrostRisk.NO_RISK,
+                    unit=None,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "simmerindex": CalculatedDataPoint(
-                    data_point_key="simmerindex", value=45.5, unit=TEMP_CELSIUS
+                    data_point_key="simmerindex",
+                    value=45.5,
+                    unit=TEMP_CELSIUS,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "simmerzone": CalculatedDataPoint(
                     data_point_key="simmerzone",
                     value=SimmerZone.DANGER_OF_HEATSTROKE,
                     unit=None,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
             },
         ),
         (
             "payload_gw1000pro.json",
             {
-                "tempin": CalculatedDataPoint("temp", 24.9, unit=TEMP_CELSIUS),
-                "humidityin": CalculatedDataPoint("humidity", 26, unit=PERCENTAGE),
-                "baromrel": CalculatedDataPoint("barom", 833.187, unit=PRESSURE_HPA),
-                "baromabs": CalculatedDataPoint("barom", 833.187, unit=PRESSURE_HPA),
-                "temp": CalculatedDataPoint("temp", -2.9, unit=TEMP_CELSIUS),
-                "humidity": CalculatedDataPoint("humidity", 27, unit=PERCENTAGE),
-                "winddir": CalculatedDataPoint("winddir", 46, unit=DEGREE),
+                "tempin": CalculatedDataPoint(
+                    "temp", 24.9, unit=TEMP_CELSIUS, data_type=DataPointType.NON_BOOLEAN
+                ),
+                "humidityin": CalculatedDataPoint(
+                    "humidity", 26, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+                ),
+                "baromrel": CalculatedDataPoint(
+                    "barom",
+                    833.187,
+                    unit=PRESSURE_HPA,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "baromabs": CalculatedDataPoint(
+                    "barom",
+                    833.187,
+                    unit=PRESSURE_HPA,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "temp": CalculatedDataPoint(
+                    "temp", -2.9, unit=TEMP_CELSIUS, data_type=DataPointType.NON_BOOLEAN
+                ),
+                "humidity": CalculatedDataPoint(
+                    "humidity", 27, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+                ),
+                "winddir": CalculatedDataPoint(
+                    "winddir", 46, unit=DEGREE, data_type=DataPointType.NON_BOOLEAN
+                ),
                 "windspeed": CalculatedDataPoint(
-                    "wind", 35.6, unit=SPEED_KILOMETERS_PER_HOUR
+                    "wind",
+                    35.6,
+                    unit=SPEED_KILOMETERS_PER_HOUR,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "windgust": CalculatedDataPoint(
-                    "gust", 7.2, unit=SPEED_KILOMETERS_PER_HOUR
+                    "gust",
+                    7.2,
+                    unit=SPEED_KILOMETERS_PER_HOUR,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "maxdailygust": CalculatedDataPoint(
-                    "gust", 25.6, unit=SPEED_KILOMETERS_PER_HOUR
+                    "gust",
+                    25.6,
+                    unit=SPEED_KILOMETERS_PER_HOUR,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "solarradiation": CalculatedDataPoint(
-                    "solarradiation", 25.56, unit=IRRADIATION_WATTS_PER_SQUARE_METER
+                    "solarradiation",
+                    25.56,
+                    unit=IRRADIATION_WATTS_PER_SQUARE_METER,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "solarradiation_lux": CalculatedDataPoint(
-                    "solarradiation_lux", 3235.4, unit=LIGHT_LUX
+                    "solarradiation_lux",
+                    3235.4,
+                    unit=LIGHT_LUX,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "solarradiation_perceived": CalculatedDataPoint(
-                    "solarradiation_perceived", 70.0, unit=PERCENTAGE
+                    "solarradiation_perceived",
+                    70.0,
+                    unit=PERCENTAGE,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
-                "uv": CalculatedDataPoint("uv", 0, unit=UV_INDEX),
+                "uv": CalculatedDataPoint(
+                    "uv", 0, unit=UV_INDEX, data_type=DataPointType.NON_BOOLEAN
+                ),
                 "safe_exposure_time_skin_type_1": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_1", None, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_1",
+                    None,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "safe_exposure_time_skin_type_2": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_2", None, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_2",
+                    None,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "safe_exposure_time_skin_type_3": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_3", None, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_3",
+                    None,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "safe_exposure_time_skin_type_4": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_4", None, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_4",
+                    None,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "safe_exposure_time_skin_type_5": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_5", None, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_5",
+                    None,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "safe_exposure_time_skin_type_6": CalculatedDataPoint(
-                    "safe_exposure_time_skin_type_6", None, unit=TIME_MINUTES
+                    "safe_exposure_time_skin_type_6",
+                    None,
+                    unit=TIME_MINUTES,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "rainrate": CalculatedDataPoint(
-                    "rainrate", 0.000, unit=f"{RAINFALL_MILLIMETERS}/hr"
+                    "rainrate",
+                    0.000,
+                    unit=f"{RAINFALL_MILLIMETERS}/hr",
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "eventrain": CalculatedDataPoint(
-                    "rain", 0.000, unit=RAINFALL_MILLIMETERS
+                    "rain",
+                    0.000,
+                    unit=RAINFALL_MILLIMETERS,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "hourlyrain": CalculatedDataPoint(
-                    "rain", 0.000, unit=RAINFALL_MILLIMETERS
+                    "rain",
+                    0.000,
+                    unit=RAINFALL_MILLIMETERS,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "dailyrain": CalculatedDataPoint(
-                    "rain", 0.000, unit=RAINFALL_MILLIMETERS
+                    "rain",
+                    0.000,
+                    unit=RAINFALL_MILLIMETERS,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "weeklyrain": CalculatedDataPoint(
-                    "rain", 0.000, unit=RAINFALL_MILLIMETERS
+                    "rain",
+                    0.000,
+                    unit=RAINFALL_MILLIMETERS,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "monthlyrain": CalculatedDataPoint(
-                    "rain", 0.000, unit=RAINFALL_MILLIMETERS
+                    "rain",
+                    0.000,
+                    unit=RAINFALL_MILLIMETERS,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "yearlyrain": CalculatedDataPoint(
-                    "rain", 298.6, unit=RAINFALL_MILLIMETERS
+                    "rain",
+                    298.6,
+                    unit=RAINFALL_MILLIMETERS,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "totalrain": CalculatedDataPoint(
-                    "rain", 298.6, unit=RAINFALL_MILLIMETERS
+                    "rain",
+                    298.6,
+                    unit=RAINFALL_MILLIMETERS,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
-                "wh65batt": CalculatedDataPoint("batt", BooleanBatteryState.OFF),
-                "dewpoint": CalculatedDataPoint("dewpoint", -19.3, unit=TEMP_CELSIUS),
-                "feelslike": CalculatedDataPoint("feelslike", -10.9, unit=TEMP_CELSIUS),
-                "heatindex": CalculatedDataPoint("heatindex", -6.5, unit=TEMP_CELSIUS),
-                "windchill": CalculatedDataPoint("windchill", -10.9, unit=TEMP_CELSIUS),
+                "wh65batt": CalculatedDataPoint(
+                    "batt",
+                    BooleanBatteryState.OFF,
+                    unit=None,
+                    data_type=DataPointType.BOOLEAN,
+                ),
+                "dewpoint": CalculatedDataPoint(
+                    "dewpoint",
+                    -19.3,
+                    unit=TEMP_CELSIUS,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "feelslike": CalculatedDataPoint(
+                    "feelslike",
+                    -10.9,
+                    unit=TEMP_CELSIUS,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "heatindex": CalculatedDataPoint(
+                    "heatindex",
+                    -6.5,
+                    unit=TEMP_CELSIUS,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
+                "windchill": CalculatedDataPoint(
+                    "windchill",
+                    -10.9,
+                    unit=TEMP_CELSIUS,
+                    data_type=DataPointType.NON_BOOLEAN,
+                ),
                 "humidityabs": CalculatedDataPoint(
                     data_point_key="humidityabs",
                     value=1.1,
                     unit=WATER_VAPOR_GRAMS_PER_CUBIC_METER,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "humidityabsin": CalculatedDataPoint(
                     data_point_key="humidityabsin",
                     value=6.2,
                     unit=WATER_VAPOR_GRAMS_PER_CUBIC_METER,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "thermalperception": CalculatedDataPoint(
                     data_point_key="thermalperception",
                     value=ThermalPerception.DRY,
                     unit=None,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "frostpoint": CalculatedDataPoint(
-                    data_point_key="frostpoint", value=-19.0, unit=TEMP_CELSIUS
+                    data_point_key="frostpoint",
+                    value=-19.0,
+                    unit=TEMP_CELSIUS,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "frostrisk": CalculatedDataPoint(
-                    data_point_key="frostrisk", value=FrostRisk.UNLIKELY, unit=None
+                    data_point_key="frostrisk",
+                    value=FrostRisk.UNLIKELY,
+                    unit=None,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "simmerindex": CalculatedDataPoint(
-                    data_point_key="simmerindex", value=None, unit=TEMP_CELSIUS
+                    data_point_key="simmerindex",
+                    value=None,
+                    unit=TEMP_CELSIUS,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
                 "simmerzone": CalculatedDataPoint(
-                    data_point_key="simmerzone", value=None, unit=None
+                    data_point_key="simmerzone",
+                    value=None,
+                    unit=None,
+                    data_type=DataPointType.NON_BOOLEAN,
                 ),
             },
         ),
@@ -1732,90 +3892,194 @@ def test_nonnumeric_value(device_data, ecowitt):
     device_data["Random New Key"] = "Some Value"
     processed_data = ProcessedData(ecowitt, device_data)
     assert processed_data.output == {
-        "runtime": CalculatedDataPoint("runtime", 319206.0, unit=TIME_SECONDS),
-        "tempin": CalculatedDataPoint("temp", 79.5, unit=TEMP_FAHRENHEIT),
-        "humidityin": CalculatedDataPoint("humidity", 31.0, unit=PERCENTAGE),
-        "baromrel": CalculatedDataPoint("barom", 24.74, unit=PRESSURE_INHG),
-        "baromabs": CalculatedDataPoint("barom", 24.74, unit=PRESSURE_INHG),
-        "temp": CalculatedDataPoint("temp", 93.2, unit=TEMP_FAHRENHEIT),
-        "humidity": CalculatedDataPoint("humidity", 64, unit=PERCENTAGE),
-        "winddir": CalculatedDataPoint("winddir", 139.0, unit=DEGREE),
-        "windspeed": CalculatedDataPoint("wind", 20.89, unit=SPEED_MILES_PER_HOUR),
-        "windgust": CalculatedDataPoint("gust", 1.12, unit=SPEED_MILES_PER_HOUR),
-        "maxdailygust": CalculatedDataPoint("gust", 8.05, unit=SPEED_MILES_PER_HOUR),
+        "runtime": CalculatedDataPoint(
+            "runtime", 319206.0, unit=TIME_SECONDS, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "tempin": CalculatedDataPoint(
+            "temp", 79.5, unit=TEMP_FAHRENHEIT, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "humidityin": CalculatedDataPoint(
+            "humidity", 31.0, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "baromrel": CalculatedDataPoint(
+            "barom", 24.74, unit=PRESSURE_INHG, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "baromabs": CalculatedDataPoint(
+            "barom", 24.74, unit=PRESSURE_INHG, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "temp": CalculatedDataPoint(
+            "temp", 93.2, unit=TEMP_FAHRENHEIT, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "humidity": CalculatedDataPoint(
+            "humidity", 64, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "winddir": CalculatedDataPoint(
+            "winddir", 139.0, unit=DEGREE, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "windspeed": CalculatedDataPoint(
+            "wind",
+            20.89,
+            unit=SPEED_MILES_PER_HOUR,
+            data_type=DataPointType.NON_BOOLEAN,
+        ),
+        "windgust": CalculatedDataPoint(
+            "gust", 1.12, unit=SPEED_MILES_PER_HOUR, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "maxdailygust": CalculatedDataPoint(
+            "gust", 8.05, unit=SPEED_MILES_PER_HOUR, data_type=DataPointType.NON_BOOLEAN
+        ),
         "solarradiation": CalculatedDataPoint(
-            "solarradiation", 264.61, unit=IRRADIATION_WATTS_PER_SQUARE_METER
+            "solarradiation",
+            264.61,
+            unit=IRRADIATION_WATTS_PER_SQUARE_METER,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "solarradiation_lux": CalculatedDataPoint(
-            "solarradiation_lux", 33494.9, unit=LIGHT_LUX
+            "solarradiation_lux",
+            33494.9,
+            unit=LIGHT_LUX,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "solarradiation_perceived": CalculatedDataPoint(
-            "solarradiation_perceived", 90.0, unit=PERCENTAGE
+            "solarradiation_perceived",
+            90.0,
+            unit=PERCENTAGE,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
-        "uv": CalculatedDataPoint("uv", 2.0, unit=UV_INDEX),
+        "uv": CalculatedDataPoint(
+            "uv", 2.0, unit=UV_INDEX, data_type=DataPointType.NON_BOOLEAN
+        ),
         "safe_exposure_time_skin_type_1": CalculatedDataPoint(
-            "safe_exposure_time_skin_type_1", 83.3, unit=TIME_MINUTES
+            "safe_exposure_time_skin_type_1",
+            83.3,
+            unit=TIME_MINUTES,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "safe_exposure_time_skin_type_2": CalculatedDataPoint(
-            "safe_exposure_time_skin_type_2", 100.0, unit=TIME_MINUTES
+            "safe_exposure_time_skin_type_2",
+            100.0,
+            unit=TIME_MINUTES,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "safe_exposure_time_skin_type_3": CalculatedDataPoint(
-            "safe_exposure_time_skin_type_3", 133.3, unit=TIME_MINUTES
+            "safe_exposure_time_skin_type_3",
+            133.3,
+            unit=TIME_MINUTES,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "safe_exposure_time_skin_type_4": CalculatedDataPoint(
-            "safe_exposure_time_skin_type_4", 166.7, unit=TIME_MINUTES
+            "safe_exposure_time_skin_type_4",
+            166.7,
+            unit=TIME_MINUTES,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "safe_exposure_time_skin_type_5": CalculatedDataPoint(
-            "safe_exposure_time_skin_type_5", 266.7, unit=TIME_MINUTES
+            "safe_exposure_time_skin_type_5",
+            266.7,
+            unit=TIME_MINUTES,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "safe_exposure_time_skin_type_6": CalculatedDataPoint(
-            "safe_exposure_time_skin_type_6", 433.3, unit=TIME_MINUTES
+            "safe_exposure_time_skin_type_6",
+            433.3,
+            unit=TIME_MINUTES,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
-        "rainrate": CalculatedDataPoint("rainrate", 0.0, unit=f"{RAINFALL_INCHES}/hr"),
-        "eventrain": CalculatedDataPoint("rain", 0.0, unit=RAINFALL_INCHES),
-        "hourlyrain": CalculatedDataPoint("rain", 0.0, unit=RAINFALL_INCHES),
-        "dailyrain": CalculatedDataPoint("rain", 0.0, unit=RAINFALL_INCHES),
-        "weeklyrain": CalculatedDataPoint("rain", 0.0, unit=RAINFALL_INCHES),
-        "monthlyrain": CalculatedDataPoint("rain", 2.177, unit=RAINFALL_INCHES),
-        "yearlyrain": CalculatedDataPoint("rain", 4.441, unit=RAINFALL_INCHES),
-        "lightning_num": CalculatedDataPoint("lightning_num", 13, unit=STRIKES),
-        "lightning": CalculatedDataPoint("lightning", 0.6, unit=DISTANCE_MILES),
+        "rainrate": CalculatedDataPoint(
+            "rainrate",
+            0.0,
+            unit=f"{RAINFALL_INCHES}/hr",
+            data_type=DataPointType.NON_BOOLEAN,
+        ),
+        "eventrain": CalculatedDataPoint(
+            "rain", 0.0, unit=RAINFALL_INCHES, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "hourlyrain": CalculatedDataPoint(
+            "rain", 0.0, unit=RAINFALL_INCHES, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "dailyrain": CalculatedDataPoint(
+            "rain", 0.0, unit=RAINFALL_INCHES, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "weeklyrain": CalculatedDataPoint(
+            "rain", 0.0, unit=RAINFALL_INCHES, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "monthlyrain": CalculatedDataPoint(
+            "rain", 2.177, unit=RAINFALL_INCHES, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "yearlyrain": CalculatedDataPoint(
+            "rain", 4.441, unit=RAINFALL_INCHES, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "lightning_num": CalculatedDataPoint(
+            "lightning_num", 13, unit=STRIKES, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "lightning": CalculatedDataPoint(
+            "lightning", 0.6, unit=DISTANCE_MILES, data_type=DataPointType.NON_BOOLEAN
+        ),
         "lightning_time": CalculatedDataPoint(
             "lightning_time", datetime(2022, 4, 20, 17, 17, 17, tzinfo=timezone.utc)
         ),
-        "wh65batt": CalculatedDataPoint("batt", BooleanBatteryState.OFF),
-        "dewpoint": CalculatedDataPoint("dewpoint", 79.2, unit=TEMP_FAHRENHEIT),
-        "feelslike": CalculatedDataPoint("feelslike", 111.1, unit=TEMP_FAHRENHEIT),
-        "heatindex": CalculatedDataPoint("heatindex", 111.1, unit=TEMP_FAHRENHEIT),
-        "windchill": CalculatedDataPoint("windchill", None, unit=TEMP_FAHRENHEIT),
+        "wh65batt": CalculatedDataPoint(
+            "batt", BooleanBatteryState.OFF, unit=None, data_type=DataPointType.BOOLEAN
+        ),
+        "dewpoint": CalculatedDataPoint(
+            "dewpoint", 79.2, unit=TEMP_FAHRENHEIT, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "feelslike": CalculatedDataPoint(
+            "feelslike",
+            111.1,
+            unit=TEMP_FAHRENHEIT,
+            data_type=DataPointType.NON_BOOLEAN,
+        ),
+        "heatindex": CalculatedDataPoint(
+            "heatindex",
+            111.1,
+            unit=TEMP_FAHRENHEIT,
+            data_type=DataPointType.NON_BOOLEAN,
+        ),
+        "windchill": CalculatedDataPoint(
+            "windchill", None, unit=TEMP_FAHRENHEIT, data_type=DataPointType.NON_BOOLEAN
+        ),
         "humidityabs": CalculatedDataPoint(
             data_point_key="humidityabs",
             value=0.0,
             unit=WATER_VAPOR_POUNDS_PER_CUBIC_FOOT,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "humidityabsin": CalculatedDataPoint(
             data_point_key="humidityabsin",
             value=0.0,
             unit=WATER_VAPOR_POUNDS_PER_CUBIC_FOOT,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "thermalperception": CalculatedDataPoint(
             data_point_key="thermalperception",
             value=ThermalPerception.SEVERELY_HIGH,
             unit=None,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "frostpoint": CalculatedDataPoint(
-            data_point_key="frostpoint", value=70.3, unit=TEMP_FAHRENHEIT
+            data_point_key="frostpoint",
+            value=70.3,
+            unit=TEMP_FAHRENHEIT,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "frostrisk": CalculatedDataPoint(
-            data_point_key="frostrisk", value=FrostRisk.NO_RISK, unit=None
+            data_point_key="frostrisk",
+            value=FrostRisk.NO_RISK,
+            unit=None,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "simmerindex": CalculatedDataPoint(
-            data_point_key="simmerindex", value=113.9, unit=TEMP_FAHRENHEIT
+            data_point_key="simmerindex",
+            value=113.9,
+            unit=TEMP_FAHRENHEIT,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "simmerzone": CalculatedDataPoint(
             data_point_key="simmerzone",
             value=SimmerZone.DANGER_OF_HEATSTROKE,
             unit=None,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "Random New Key": CalculatedDataPoint("Random New Key", "Some Value"),
     }
@@ -1848,92 +4112,196 @@ def test_unknown_battery(device_data, ecowitt):
     device_data["playstationbattery1"] = 0
     processed_data = ProcessedData(ecowitt, device_data)
     assert processed_data.output == {
-        "runtime": CalculatedDataPoint("runtime", 319206.0, unit=TIME_SECONDS),
-        "tempin": CalculatedDataPoint("temp", 79.5, unit=TEMP_FAHRENHEIT),
-        "humidityin": CalculatedDataPoint("humidity", 31.0, unit=PERCENTAGE),
-        "baromrel": CalculatedDataPoint("barom", 24.74, unit=PRESSURE_INHG),
-        "baromabs": CalculatedDataPoint("barom", 24.74, unit=PRESSURE_INHG),
-        "temp": CalculatedDataPoint("temp", 93.2, unit=TEMP_FAHRENHEIT),
-        "humidity": CalculatedDataPoint("humidity", 64, unit=PERCENTAGE),
-        "winddir": CalculatedDataPoint("winddir", 139.0, unit=DEGREE),
-        "windspeed": CalculatedDataPoint("wind", 20.89, unit=SPEED_MILES_PER_HOUR),
-        "windgust": CalculatedDataPoint("gust", 1.12, unit=SPEED_MILES_PER_HOUR),
-        "maxdailygust": CalculatedDataPoint("gust", 8.05, unit=SPEED_MILES_PER_HOUR),
+        "runtime": CalculatedDataPoint(
+            "runtime", 319206.0, unit=TIME_SECONDS, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "tempin": CalculatedDataPoint(
+            "temp", 79.5, unit=TEMP_FAHRENHEIT, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "humidityin": CalculatedDataPoint(
+            "humidity", 31.0, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "baromrel": CalculatedDataPoint(
+            "barom", 24.74, unit=PRESSURE_INHG, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "baromabs": CalculatedDataPoint(
+            "barom", 24.74, unit=PRESSURE_INHG, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "temp": CalculatedDataPoint(
+            "temp", 93.2, unit=TEMP_FAHRENHEIT, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "humidity": CalculatedDataPoint(
+            "humidity", 64, unit=PERCENTAGE, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "winddir": CalculatedDataPoint(
+            "winddir", 139.0, unit=DEGREE, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "windspeed": CalculatedDataPoint(
+            "wind",
+            20.89,
+            unit=SPEED_MILES_PER_HOUR,
+            data_type=DataPointType.NON_BOOLEAN,
+        ),
+        "windgust": CalculatedDataPoint(
+            "gust", 1.12, unit=SPEED_MILES_PER_HOUR, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "maxdailygust": CalculatedDataPoint(
+            "gust", 8.05, unit=SPEED_MILES_PER_HOUR, data_type=DataPointType.NON_BOOLEAN
+        ),
         "solarradiation": CalculatedDataPoint(
-            "solarradiation", 264.61, unit=IRRADIATION_WATTS_PER_SQUARE_METER
+            "solarradiation",
+            264.61,
+            unit=IRRADIATION_WATTS_PER_SQUARE_METER,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "solarradiation_lux": CalculatedDataPoint(
-            "solarradiation_lux", 33494.9, unit=LIGHT_LUX
+            "solarradiation_lux",
+            33494.9,
+            unit=LIGHT_LUX,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "solarradiation_perceived": CalculatedDataPoint(
-            "solarradiation_perceived", 90.0, unit=PERCENTAGE
+            "solarradiation_perceived",
+            90.0,
+            unit=PERCENTAGE,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
-        "uv": CalculatedDataPoint("uv", 2.0, unit=UV_INDEX),
+        "uv": CalculatedDataPoint(
+            "uv", 2.0, unit=UV_INDEX, data_type=DataPointType.NON_BOOLEAN
+        ),
         "safe_exposure_time_skin_type_1": CalculatedDataPoint(
-            "safe_exposure_time_skin_type_1", 83.3, unit=TIME_MINUTES
+            "safe_exposure_time_skin_type_1",
+            83.3,
+            unit=TIME_MINUTES,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "safe_exposure_time_skin_type_2": CalculatedDataPoint(
-            "safe_exposure_time_skin_type_2", 100.0, unit=TIME_MINUTES
+            "safe_exposure_time_skin_type_2",
+            100.0,
+            unit=TIME_MINUTES,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "safe_exposure_time_skin_type_3": CalculatedDataPoint(
-            "safe_exposure_time_skin_type_3", 133.3, unit=TIME_MINUTES
+            "safe_exposure_time_skin_type_3",
+            133.3,
+            unit=TIME_MINUTES,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "safe_exposure_time_skin_type_4": CalculatedDataPoint(
-            "safe_exposure_time_skin_type_4", 166.7, unit=TIME_MINUTES
+            "safe_exposure_time_skin_type_4",
+            166.7,
+            unit=TIME_MINUTES,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "safe_exposure_time_skin_type_5": CalculatedDataPoint(
-            "safe_exposure_time_skin_type_5", 266.7, unit=TIME_MINUTES
+            "safe_exposure_time_skin_type_5",
+            266.7,
+            unit=TIME_MINUTES,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "safe_exposure_time_skin_type_6": CalculatedDataPoint(
-            "safe_exposure_time_skin_type_6", 433.3, unit=TIME_MINUTES
+            "safe_exposure_time_skin_type_6",
+            433.3,
+            unit=TIME_MINUTES,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
-        "rainrate": CalculatedDataPoint("rainrate", 0.0, unit=f"{RAINFALL_INCHES}/hr"),
-        "eventrain": CalculatedDataPoint("rain", 0.0, unit=RAINFALL_INCHES),
-        "hourlyrain": CalculatedDataPoint("rain", 0.0, unit=RAINFALL_INCHES),
-        "dailyrain": CalculatedDataPoint("rain", 0.0, unit=RAINFALL_INCHES),
-        "weeklyrain": CalculatedDataPoint("rain", 0.0, unit=RAINFALL_INCHES),
-        "monthlyrain": CalculatedDataPoint("rain", 2.177, unit=RAINFALL_INCHES),
-        "yearlyrain": CalculatedDataPoint("rain", 4.441, unit=RAINFALL_INCHES),
-        "lightning_num": CalculatedDataPoint("lightning_num", 13, unit=STRIKES),
-        "lightning": CalculatedDataPoint("lightning", 0.6, unit=DISTANCE_MILES),
+        "rainrate": CalculatedDataPoint(
+            "rainrate",
+            0.0,
+            unit=f"{RAINFALL_INCHES}/hr",
+            data_type=DataPointType.NON_BOOLEAN,
+        ),
+        "eventrain": CalculatedDataPoint(
+            "rain", 0.0, unit=RAINFALL_INCHES, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "hourlyrain": CalculatedDataPoint(
+            "rain", 0.0, unit=RAINFALL_INCHES, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "dailyrain": CalculatedDataPoint(
+            "rain", 0.0, unit=RAINFALL_INCHES, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "weeklyrain": CalculatedDataPoint(
+            "rain", 0.0, unit=RAINFALL_INCHES, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "monthlyrain": CalculatedDataPoint(
+            "rain", 2.177, unit=RAINFALL_INCHES, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "yearlyrain": CalculatedDataPoint(
+            "rain", 4.441, unit=RAINFALL_INCHES, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "lightning_num": CalculatedDataPoint(
+            "lightning_num", 13, unit=STRIKES, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "lightning": CalculatedDataPoint(
+            "lightning", 0.6, unit=DISTANCE_MILES, data_type=DataPointType.NON_BOOLEAN
+        ),
         "lightning_time": CalculatedDataPoint(
             "lightning_time", datetime(2022, 4, 20, 17, 17, 17, tzinfo=timezone.utc)
         ),
-        "wh65batt": CalculatedDataPoint("batt", BooleanBatteryState.OFF),
-        "dewpoint": CalculatedDataPoint("dewpoint", 79.2, unit=TEMP_FAHRENHEIT),
-        "feelslike": CalculatedDataPoint("feelslike", 111.1, unit=TEMP_FAHRENHEIT),
-        "heatindex": CalculatedDataPoint("heatindex", 111.1, unit=TEMP_FAHRENHEIT),
-        "windchill": CalculatedDataPoint("windchill", None, unit=TEMP_FAHRENHEIT),
+        "wh65batt": CalculatedDataPoint(
+            "batt", BooleanBatteryState.OFF, unit=None, data_type=DataPointType.BOOLEAN
+        ),
+        "dewpoint": CalculatedDataPoint(
+            "dewpoint", 79.2, unit=TEMP_FAHRENHEIT, data_type=DataPointType.NON_BOOLEAN
+        ),
+        "feelslike": CalculatedDataPoint(
+            "feelslike",
+            111.1,
+            unit=TEMP_FAHRENHEIT,
+            data_type=DataPointType.NON_BOOLEAN,
+        ),
+        "heatindex": CalculatedDataPoint(
+            "heatindex",
+            111.1,
+            unit=TEMP_FAHRENHEIT,
+            data_type=DataPointType.NON_BOOLEAN,
+        ),
+        "windchill": CalculatedDataPoint(
+            "windchill", None, unit=TEMP_FAHRENHEIT, data_type=DataPointType.NON_BOOLEAN
+        ),
         "humidityabs": CalculatedDataPoint(
             data_point_key="humidityabs",
             value=0.0,
             unit=WATER_VAPOR_POUNDS_PER_CUBIC_FOOT,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "humidityabsin": CalculatedDataPoint(
             data_point_key="humidityabsin",
             value=0.0,
             unit=WATER_VAPOR_POUNDS_PER_CUBIC_FOOT,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "thermalperception": CalculatedDataPoint(
             data_point_key="thermalperception",
             value=ThermalPerception.SEVERELY_HIGH,
             unit=None,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "frostpoint": CalculatedDataPoint(
-            data_point_key="frostpoint", value=70.3, unit=TEMP_FAHRENHEIT
+            data_point_key="frostpoint",
+            value=70.3,
+            unit=TEMP_FAHRENHEIT,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "frostrisk": CalculatedDataPoint(
-            data_point_key="frostrisk", value=FrostRisk.NO_RISK, unit=None
+            data_point_key="frostrisk",
+            value=FrostRisk.NO_RISK,
+            unit=None,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "simmerindex": CalculatedDataPoint(
-            data_point_key="simmerindex", value=113.9, unit=TEMP_FAHRENHEIT
+            data_point_key="simmerindex",
+            value=113.9,
+            unit=TEMP_FAHRENHEIT,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "simmerzone": CalculatedDataPoint(
             data_point_key="simmerzone",
             value=SimmerZone.DANGER_OF_HEATSTROKE,
             unit=None,
+            data_type=DataPointType.NON_BOOLEAN,
         ),
         "playstationbattery1": CalculatedDataPoint(
-            "batt", BooleanBatteryState.OFF, None
+            "batt", BooleanBatteryState.OFF, unit=None, data_type=DataPointType.BOOLEAN
         ),
     }


### PR DESCRIPTION
**Describe what the PR does:**

The current HASS MQTT Discovery logic incorrectly interprets some sensors as binary sensors (when they should be sensors). This PR fixes the bug.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
