### PR TITLE
Log debug-level statements when the temperature is too low to calculate simmer index and simmer zone

### DIFF
--- a/ecowitt2mqtt/helpers/calculator/meteo.py
+++ b/ecowitt2mqtt/helpers/calculator/meteo.py
@@ -595,8 +595,8 @@ def calculate_simmer_index(
             final_value = round(simmer_obj.c, 1)
     else:
         LOGGER.debug(
-            "Simmer index is only defined for temperatures over 70°F (temperature: %s",
-            temperature,
+            "Simmer index is undefined for temperatures below 70°F (temperature: %s°F",
+            temp_obj.f,
         )
         final_value = None
 
@@ -625,8 +625,8 @@ def calculate_simmer_zone(
         final_value = rating.zone
     else:
         LOGGER.debug(
-            "Simmer zone is only defined for temperatures over 70°F (temperature: %s",
-            temperature,
+            "Simmer index is undefined for temperatures below 70°F (temperature: %s°F",
+            temp_obj.f,
         )
         final_value = None
 

--- a/ecowitt2mqtt/helpers/calculator/meteo.py
+++ b/ecowitt2mqtt/helpers/calculator/meteo.py
@@ -594,6 +594,10 @@ def calculate_simmer_index(
         else:
             final_value = round(simmer_obj.c, 1)
     else:
+        LOGGER.debug(
+            "Simmer index is only defined for temperatures over 70°F (temperature: %s",
+            temperature,
+        )
         final_value = None
 
     return CalculatedDataPoint(

--- a/ecowitt2mqtt/helpers/calculator/meteo.py
+++ b/ecowitt2mqtt/helpers/calculator/meteo.py
@@ -624,6 +624,10 @@ def calculate_simmer_zone(
         ]
         final_value = rating.zone
     else:
+        LOGGER.debug(
+            "Simmer zone is only defined for temperatures over 70°F (temperature: %s",
+            temperature,
+        )
         final_value = None
 
     return CalculatedDataPoint(data_point_key=data_point_key, value=final_value)


### PR DESCRIPTION
**Describe what the PR does:**

The wind chill calculator logs a debug message when the current temperature/wind speed doesn't yield a wind chill; since a similar thing can happen to the simmer index, this PR adds the same debug log statements for simmer index and simmer zone.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
