### PR TITLE
Add Home Assistant OS instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ You can provide a custom prefix for all Home Assistant entities via the
 Home Assistant OS users can install the official `ecowitt2mqtt` add-on by clicking the
 link below:
 
-[![Open this add-on in your Home Assistant instance.][https://my.home-assistant.io/badges/supervisor_addon.svg]][https://my.home-assistant.io/redirect/supervisor_addon/?addon=c35f0383_ecowitt2mqtt&repository_url=https%3A%2F%2Fgithub.com%2Fbachya%2Fhome-assistant-addons]
+[![Open this add-on in your Home Assistant instance.][addon-badge]][addon]
 
 ## Running in the Background
 
@@ -531,3 +531,6 @@ debugging, and issue reporting.
 9. Update `README.md` with any new documentation.
 10. Add yourself to `AUTHORS.md`.
 11. Submit a pull request!
+
+[addon-badge]: https://my.home-assistant.io/badges/supervisor_addon.svg
+[addon]: https://my.home-assistant.io/redirect/supervisor_addon/?addon=c35f0383_ecowitt2mqtt&repository_url=https%3A%2F%2Fgithub.com%2Fbachya%2Fhome-assistant-addons

--- a/README.md
+++ b/README.md
@@ -426,6 +426,13 @@ win out.
 You can provide a custom prefix for all Home Assistant entities via the
 `--hass-entity-id-prefix` config parameter.
 
+### Home Assistant OS Add-on
+
+Home Assistant OS users can install the official `ecowitt2mqtt` add-on by clicking the
+link below:
+
+[![Open this add-on in your Home Assistant instance.][https://my.home-assistant.io/badges/supervisor_addon.svg]][https://my.home-assistant.io/redirect/supervisor_addon/?addon=c35f0383_ecowitt2mqtt&repository_url=https%3A%2F%2Fgithub.com%2Fbachya%2Fhome-assistant-addons]
+
 ## Running in the Background
 
 `ecowitt2mqtt` doesn't, itself, provide any sort of daemonization mechanism. The suggested


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds a docs link to install [the official Home Assistant OS add-on](https://github.com/bachya/home-assistant-addons/tree/dev/ecowitt2mqtt).

**Does this fix a specific issue?**

Fixes https://github.com/bachya/ecowitt2mqtt/issues/208

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Run tests and ensure everything passes (with 100% test coverage).
- [x] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
