### PR TITLE
Remove unnecessary reference to the event loop

### DIFF
--- a/ecowitt2mqtt/server.py
+++ b/ecowitt2mqtt/server.py
@@ -26,7 +26,6 @@ class Server:
 
     def __init__(self, ecowitt: Ecowitt) -> None:
         """Initialize."""
-        self._loop = asyncio.get_event_loop()
         self._startup_task: asyncio.Task | None = None
 
         self.app = FastAPI()
@@ -38,7 +37,6 @@ class Server:
                 host=DEFAULT_HOST,
                 port=ecowitt.config.port,
                 log_level="debug" if ecowitt.config.verbose else "error",
-                loop=self._loop,
             )
         )
 
@@ -72,7 +70,7 @@ class Server:
             response_class=Response,
         )(self._async_post_data)
 
-        self._startup_task = self._loop.create_task(self.server.serve())
+        self._startup_task = asyncio.create_task(self.server.serve())
         try:
             await self._startup_task
         except asyncio.CancelledError:


### PR DESCRIPTION
**Describe what the PR does:**

At some point in the past, we needed to store (and pass around) a reference to the `uvloop` event loop for the server to publish correctly. Doesn't appear necessary now (and in fact, throws a warning in some unrelated tests). This PR removes the references.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
