### PR TITLE
Add `--version` flag (and corresponding version log entry)

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Options:
                                   ECOWITT2MQTT_RAW_DATA, RAW_DATA]
   -v, --verbose                   Increase verbosity of logged output.  [env
                                   var: ECOWITT2MQTT_VERBOSE]
+  --version                       Return the application version.
   --install-completion            Install completion for the current shell.
   --show-completion               Show completion for the current shell, to
                                   copy it or customize the installation.

--- a/ecowitt2mqtt/cli.py
+++ b/ecowitt2mqtt/cli.py
@@ -44,6 +44,7 @@ from ecowitt2mqtt.const import (
     LEGACY_ENV_RAW_DATA,
     UNIT_SYSTEM_IMPERIAL,
     UNIT_SYSTEM_METRIC,
+    __version__ as ecowitt2mqtt_version,
 )
 from ecowitt2mqtt.core import Ecowitt
 from ecowitt2mqtt.helpers.calculator.battery import BatteryStrategy
@@ -207,8 +208,17 @@ def main(  # pylint: disable=too-many-arguments,too-many-locals
         envvar=[ENV_VERBOSE],
         help="Increase verbosity of logged output.",
     ),
+    version: bool = typer.Option(
+        False,
+        "--version",
+        help="Return the application version.",
+    ),
 ) -> None:
     """ecowitt2mqtt sends Ecowitt device data to an MQTT broker."""
+    if version:
+        typer.echo(ecowitt2mqtt_version)
+        raise typer.Exit(code=0)
+
     loop = uvloop.new_event_loop()
     asyncio.set_event_loop(loop)
 

--- a/ecowitt2mqtt/core.py
+++ b/ecowitt2mqtt/core.py
@@ -6,7 +6,12 @@ import os
 from typing import Any
 
 from ecowitt2mqtt.config import Config
-from ecowitt2mqtt.const import CONF_VERBOSE, LEGACY_ENV_LOG_LEVEL
+from ecowitt2mqtt.const import (
+    CONF_VERBOSE,
+    LEGACY_ENV_LOG_LEVEL,
+    LOGGER,
+    __version__ as ecowitt2mqtt_version,
+)
 from ecowitt2mqtt.helpers.logging import TyperLoggerHandler
 from ecowitt2mqtt.runtime import Runtime
 
@@ -37,4 +42,5 @@ class Ecowitt:  # pylint: disable=too-few-public-methods
 
     async def async_start(self) -> None:
         """Start ecowitt2mqtt."""
+        LOGGER.info("Starting ecowitt2mqtt (version %s)", ecowitt2mqtt_version)
         await self._runtime.async_start()


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds a `--version` flag to quickly print out the library version. It also adds the version to the startup logs.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [x] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
