### PR TITLE
Ensure renovate labels issues with `dependencies`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,6 @@
     "schedule:monthly",
     ":disableDependencyDashboard"
   ],
+  "labels": ["dependencies"],
   "separateMinorPatch": true
 }


### PR DESCRIPTION
**Describe what the PR does:**

This PR ensures that when renovate opens PRs, it tags them with `dependencies`.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
