### PR TITLE
Make Uvicorn only output `ERROR`-level logs when not using verbose mode

### DIFF
--- a/ecowitt2mqtt/runtime.py
+++ b/ecowitt2mqtt/runtime.py
@@ -22,9 +22,6 @@ if TYPE_CHECKING:
 DEFAULT_HOST = "0.0.0.0"
 DEFAULT_MAX_RETRY_INTERVAL = 60
 
-LOG_LEVEL_DEBUG = "debug"
-LOG_LEVEL_ERROR = "error"
-
 HANDLED_SIGNALS = (
     signal.SIGINT,  # Unix signal 2. Sent by Ctrl+C.
     signal.SIGTERM,  # Unix signal 15. Sent by `kill <pid>`.
@@ -57,7 +54,7 @@ class Runtime:
                 app,
                 host=DEFAULT_HOST,
                 port=ecowitt.config.port,
-                log_level="debug" if ecowitt.config.verbose else "info",
+                log_level="debug" if ecowitt.config.verbose else "error",
             )
         )
 


### PR DESCRIPTION
**Describe what the PR does:**

After experimenting with `INFO`-level Uvicorn logs, they add verbosity without much benefit. So, this PR adjusts Uvicorn to output `ERROR`-level logs (unless `--verbose` is used).

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
