### PR TITLE
Use `python:3.10-slim-bullseye` as a Docker image base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim as base
+FROM python:3.10-slim-bullseye as base
 ENV PYTHONFAULTHANDLER=1 \
     PYTHONHASHSEED=random \
     PYTHONUNBUFFERED=1
@@ -12,10 +12,7 @@ WORKDIR /app
 RUN apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
-        gcc \
-        python3-dev \
-        python3-pip \
-        python3-venv \
+        build-essential \
     && python3 -m pip install poetry \
     && python3 -m venv /venv
 COPY pyproject.toml ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-alpine as base
+FROM debian:bullseye-slim as base
 ENV PYTHONFAULTHANDLER=1 \
     PYTHONHASHSEED=random \
     PYTHONUNBUFFERED=1
@@ -8,18 +8,14 @@ ENV PIP_DEFAULT_TIMEOUT=100 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PIP_NO_CACHE_DIR=1
 WORKDIR /app
-# hadolint ignore=DL3018,DL3013
-RUN apk add --no-cache \
-        bash \
-        build-base \
-        cargo \
+# hadolint ignore=DL3008,DL3013
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends \
         gcc \
-        libffi-dev \
-        musl-dev \
-        openssl-dev \
         python3-dev \
-    && python3 -m pip install --upgrade pip \
-    && python3 -m pip install cryptography \
+        python3-pip \
+        python3-venv \
     && python3 -m pip install poetry \
     && python3 -m venv /venv
 COPY pyproject.toml ./


### PR DESCRIPTION
**Describe what the PR does:**

It's becoming quite a chore to maintain an Alpine-based image (example:[ the ongoing challenge of building `cryptography`](https://github.com/pyca/cryptography/issues/5771)). The small disk savings we get isn't worth it. This PR moves the base image to `python:3.10-slim-bullseye`.

**Does this fix a specific issue?**

Fixes https://github.com/bachya/ecowitt2mqtt/issues/<ISSUE ID>

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
