### PR TITLE
Don't log warning during data type conversion

### DIFF
--- a/ecowitt2mqtt/data.py
+++ b/ecowitt2mqtt/data.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from functools import partial
-import traceback
 from typing import TYPE_CHECKING, Any, Callable, TypeVar
 
 from ecowitt2mqtt.const import (
@@ -212,9 +211,7 @@ def get_typed_value(value: T) -> int | float | T:
 
     try:
         return float(value)  # type: ignore[arg-type]
-    except Exception as err:  # pylint: disable=broad-except
-        LOGGER.warning("Couldn't convert value to number: %s", value)
-        LOGGER.debug("".join(traceback.format_tb(err.__traceback__)))
+    except ValueError:
         return value
 
 

--- a/tests/publisher/test_topic_publisher.py
+++ b/tests/publisher/test_topic_publisher.py
@@ -58,7 +58,7 @@ async def test_publish_error_unserializable(
     device_data, ecowitt, mock_asyncio_mqtt_client, setup_asyncio_mqtt
 ):
     """Test handling a serialization error when publishing."""
-    device_data["Test"] = object()
+    device_data["Test"] = b"Binary value"
     publisher = get_publisher(ecowitt)
     with pytest.raises(TypeError):
         await publisher.async_publish(mock_asyncio_mqtt_client, device_data)


### PR DESCRIPTION
**Describe what the PR does:**

We shouldn't log an issue when the `data` module can't parse a value as a number (since we can have non-numeric values). Downstream calculators can choose whether they want to handle an issue or not.

**Does this fix a specific issue?**

Fixes https://github.com/bachya/ecowitt2mqtt/issues/<ISSUE ID>

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
