### PR TITLE
Fix bug with empty lightning strike time value

### DIFF
--- a/ecowitt2mqtt/helpers/calculator/meteo.py
+++ b/ecowitt2mqtt/helpers/calculator/meteo.py
@@ -741,7 +741,7 @@ def calculate_lightning_strike_distance(
     Note that lightning strike distances always have metric as the input unit system.
     """
     try:
-        final_value = int(value)
+        final_value = float(value)
     except ValueError:
         LOGGER.debug("Can't convert value to number: %s", value)
         return CalculatedDataPoint(data_point_key=data_point_key, value=None)

--- a/ecowitt2mqtt/helpers/calculator/meteo.py
+++ b/ecowitt2mqtt/helpers/calculator/meteo.py
@@ -740,6 +740,12 @@ def calculate_lightning_strike_distance(
 
     Note that lightning strike distances always have metric as the input unit system.
     """
+    try:
+        final_value = int(value)
+    except ValueError:
+        LOGGER.debug("Can't convert value to number: %s", value)
+        return CalculatedDataPoint(data_point_key=data_point_key, value=None)
+
     if ecowitt.config.output_unit_system == UNIT_SYSTEM_METRIC:
         final_value = value
     else:

--- a/ecowitt2mqtt/helpers/calculator/time.py
+++ b/ecowitt2mqtt/helpers/calculator/time.py
@@ -20,6 +20,7 @@ def calculate_dt_from_epoch(
     except ValueError:
         LOGGER.debug("Can't convert value to number: %s", value)
         return CalculatedDataPoint(data_point_key=data_point_key, value=None)
+
     return CalculatedDataPoint(
         data_point_key=data_point_key,
         value=datetime.utcfromtimestamp(float_value).replace(tzinfo=timezone.utc),

--- a/ecowitt2mqtt/helpers/publisher/hass.py
+++ b/ecowitt2mqtt/helpers/publisher/hass.py
@@ -288,7 +288,6 @@ ENTITY_DESCRIPTIONS = {
     ),
     DATA_POINT_LIGHTNING_TIME: EntityDescription(
         device_class=DeviceClass.TIMESTAMP,
-        state_class=StateClass.MEASUREMENT,
     ),
     DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_1: EntityDescription(
         icon="mdi:timer",

--- a/tests/fixtures/payload_gw2000a_1.json
+++ b/tests/fixtures/payload_gw2000a_1.json
@@ -25,7 +25,7 @@
   "ws90cap_volt": "0.6",
   "ws90_ver": "119",
   "lightning_num": "1",
-  "lightning": "27",
+  "lightning": "",
   "lightning_time": "",
   "wh57batt": "5",
   "wh90batt": "3.16",

--- a/tests/publisher/test_hass_discovery.py
+++ b/tests/publisher/test_hass_discovery.py
@@ -1294,7 +1294,7 @@ async def test_publish(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/lightning_time/config",
-                payload=b'{"availability_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/lightning_time/availability", "device": {"identifiers": ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"], "manufacturer": "Ecowitt", "model": "GW2000A", "name": "GW2000A", "sw_version": "GW2000A_V2.1.4"}, "json_attributes_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/lightning_time/attributes", "name": "lightning_time", "qos": 1, "retain": false, "state_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/lightning_time/state", "unique_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_lightning_time", "device_class": "timestamp", "state_class": "measurement"}',
+                payload=b'{"availability_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/lightning_time/availability", "device": {"identifiers": ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"], "manufacturer": "Ecowitt", "model": "GW2000A", "name": "GW2000A", "sw_version": "GW2000A_V2.1.4"}, "json_attributes_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/lightning_time/attributes", "name": "lightning_time", "qos": 1, "retain": false, "state_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/lightning_time/state", "unique_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_lightning_time", "device_class": "timestamp"}',
                 retain=False,
             ),
             call(
@@ -3339,7 +3339,7 @@ async def test_publish_custom_entity_id_prefix(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/lightning_time/config",
-                payload=b'{"availability_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/lightning_time/availability", "device": {"identifiers": ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"], "manufacturer": "Ecowitt", "model": "GW2000A", "name": "GW2000A", "sw_version": "GW2000A_V2.1.4"}, "json_attributes_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/lightning_time/attributes", "name": "test_prefix_lightning_time", "qos": 1, "retain": false, "state_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/lightning_time/state", "unique_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_lightning_time", "device_class": "timestamp", "state_class": "measurement"}',
+                payload=b'{"availability_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/lightning_time/availability", "device": {"identifiers": ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"], "manufacturer": "Ecowitt", "model": "GW2000A", "name": "GW2000A", "sw_version": "GW2000A_V2.1.4"}, "json_attributes_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/lightning_time/attributes", "name": "test_prefix_lightning_time", "qos": 1, "retain": false, "state_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/lightning_time/state", "unique_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_lightning_time", "device_class": "timestamp"}',
                 retain=False,
             ),
             call(
@@ -5408,7 +5408,7 @@ async def test_publish_numeric_battery_strategy(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/lightning_time/config",
-                payload=b'{"availability_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/lightning_time/availability", "device": {"identifiers": ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"], "manufacturer": "Ecowitt", "model": "GW2000A", "name": "GW2000A", "sw_version": "GW2000A_V2.1.4"}, "json_attributes_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/lightning_time/attributes", "name": "lightning_time", "qos": 1, "retain": false, "state_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/lightning_time/state", "unique_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_lightning_time", "device_class": "timestamp", "state_class": "measurement"}',
+                payload=b'{"availability_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/lightning_time/availability", "device": {"identifiers": ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"], "manufacturer": "Ecowitt", "model": "GW2000A", "name": "GW2000A", "sw_version": "GW2000A_V2.1.4"}, "json_attributes_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/lightning_time/attributes", "name": "lightning_time", "qos": 1, "retain": false, "state_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/lightning_time/state", "unique_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_lightning_time", "device_class": "timestamp"}',
                 retain=False,
             ),
             call(
@@ -7455,7 +7455,7 @@ async def test_no_entity_description(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/lightning_time/config",
-                payload=b'{"availability_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/lightning_time/availability", "device": {"identifiers": ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"], "manufacturer": "Ecowitt", "model": "GW2000A", "name": "GW2000A", "sw_version": "GW2000A_V2.1.4"}, "json_attributes_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/lightning_time/attributes", "name": "lightning_time", "qos": 1, "retain": false, "state_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/lightning_time/state", "unique_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_lightning_time", "device_class": "timestamp", "state_class": "measurement"}',
+                payload=b'{"availability_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/lightning_time/availability", "device": {"identifiers": ["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"], "manufacturer": "Ecowitt", "model": "GW2000A", "name": "GW2000A", "sw_version": "GW2000A_V2.1.4"}, "json_attributes_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/lightning_time/attributes", "name": "lightning_time", "qos": 1, "retain": false, "state_topic": "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/lightning_time/state", "unique_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_lightning_time", "device_class": "timestamp"}',
                 retain=False,
             ),
             call(

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1197,8 +1197,8 @@ def test_missing_distance(device_data, ecowitt, request):
         ),
         "lightning": CalculatedDataPoint(
             "lightning",
-            16.8,
-            unit=DISTANCE_MILES,
+            None,
+            unit=None,
             attributes={},
             data_type=DataPointType.NON_BOOLEAN,
         ),
@@ -2975,8 +2975,8 @@ def test_nonnumeric_value(device_data, ecowitt):
                 ),
                 "lightning": CalculatedDataPoint(
                     "lightning",
-                    16.8,
-                    unit=DISTANCE_MILES,
+                    None,
+                    unit=None,
                     attributes={},
                     data_type=DataPointType.NON_BOOLEAN,
                 ),


### PR DESCRIPTION
**Describe what the PR does:**

We currently handle empty values in most places, but one I had forgotten was an empty lightning strike timestamp. This PR fixes that.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
