### PR TITLE
Wait for all tasks to finish on shutdown

### DIFF
--- a/ecowitt2mqtt/runtime.py
+++ b/ecowitt2mqtt/runtime.py
@@ -158,7 +158,11 @@ class Runtime:
         try:
             await asyncio.gather(*self._runtime_tasks)
         except asyncio.CancelledError:
-            await asyncio.sleep(0.1)
+            for task in self._runtime_tasks:
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
             LOGGER.debug("Runtime shutdown complete")
 
     def stop(self) -> None:


### PR DESCRIPTION
**Describe what the PR does:**

The `Runtime` object's shutdown is a bit fire-and-forget: we instruct all tasks to cancel, wait for 1 extra iteration of the event loop, and trust that everything cancels correctly. This works, but it's lucky.

This PR modifies things so that as soon as either runtime task is canceled, `Runtime` waits for both tasks to _actually_ finish canceling before exiting.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
