### PR TITLE
Fix unhandled exception when calculating Beaufort Scale

### DIFF
--- a/ecowitt2mqtt/helpers/calculator/meteo.py
+++ b/ecowitt2mqtt/helpers/calculator/meteo.py
@@ -583,11 +583,11 @@ def calculate_beaufort_scale(
         for r in BEAUFORT_SCALE_RATINGS
         if (
             ecowitt.config.input_unit_system == UNIT_SYSTEM_IMPERIAL
-            and r.minimum_mph <= wind_speed <= r.maximum_mph
+            and r.minimum_mph <= wind_speed < r.maximum_mph
         )
         or (
             ecowitt.config.input_unit_system == UNIT_SYSTEM_METRIC
-            and r.minimum_kmh <= wind_speed <= r.maximum_kmh
+            and r.minimum_kmh <= wind_speed < r.maximum_kmh
         )
     ]
 


### PR DESCRIPTION
**Describe what the PR does:**

The current logic for calculating the Beaufort Scale will fail if a windspeed matches more than one rating. This PR removes the overlap that causes the exception.

**Does this fix a specific issue?**

Fixes https://github.com/bachya/ecowitt2mqtt/issues/260

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
