### PR TITLE
Fix unhandled exception when calculating Simmer Zone

### DIFF
--- a/ecowitt2mqtt/helpers/calculator/meteo.py
+++ b/ecowitt2mqtt/helpers/calculator/meteo.py
@@ -924,7 +924,7 @@ def calculate_simmer_zone(
     else:
         assert simmer_obj
         [rating] = [
-            r for r in SIMMER_ZONE_RATINGS if r.minimum_f <= simmer_obj.f <= r.maximum_f
+            r for r in SIMMER_ZONE_RATINGS if r.minimum_f <= simmer_obj.f < r.maximum_f
         ]
         final_value = rating.zone
 


### PR DESCRIPTION
**Describe what the PR does:**

Following up on https://github.com/bachya/ecowitt2mqtt/pull/261, I realize there is a small-but-nonzero chance of a similar overlap exception when calculating the Simmer Zone. This PR fixes the overlap.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
