### PR TITLE
Fix unhandled exception when calculating Thermal Perception

### DIFF
--- a/ecowitt2mqtt/helpers/calculator/meteo.py
+++ b/ecowitt2mqtt/helpers/calculator/meteo.py
@@ -1014,7 +1014,7 @@ def calculate_thermal_perception(
     [rating] = [
         r
         for r in THERMAL_PERCEPTION_RATINGS
-        if r.minimum_c <= dew_point_obj.c <= r.maximum_c
+        if r.minimum_c <= dew_point_obj.c < r.maximum_c
     ]
 
     return CalculatedDataPoint(data_point_key=data_point_key, value=rating.perception)


### PR DESCRIPTION
**Describe what the PR does:**

Following up on https://github.com/bachya/ecowitt2mqtt/pull/261, I realize there is a small-but-nonzero chance of a similar overlap exception when calculating the Thermal Perception. This PR fixes the overlap.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
