### PR TITLE
Remove no-longer-used `pylint` option

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,12 +93,10 @@ expected-line-ending-format = "LF"
 
 [tool.pylint."MESSAGES CONTROL"]
 # Reasons disabled:
-# bad-continuation - Invalid attack on black
 # too-few-public-methods - Often irrelevant
 # unnecessary-pass - This can hurt readability
 # unused-argument – Typer's modeling uses this everywhere
 disable = [
-  "bad-continuation",
   "too-few-public-methods",
   "unnecessary-pass",
   "unused-argument",


### PR DESCRIPTION
**Describe what the PR does:**

[Modern `pylint` has removed `bad-continuation`](https://github.com/PyCQA/pylint/issues/3565), so we should, too.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
