### PR TITLE
Add debug message when safe exposure time can't be calculated

### DIFF
--- a/ecowitt2mqtt/helpers/calculator/meteo.py
+++ b/ecowitt2mqtt/helpers/calculator/meteo.py
@@ -862,7 +862,7 @@ def calculate_safe_exposure_time(
         final_value = round((200 * safe_exposure_info.constant) / (3 * value), 1)
     except ZeroDivisionError:
         LOGGER.debug(
-            "Safe exposure times are only valid for UV indices above 0 (current: %s)",
+            "Safe exposure times are only valid for non-zero UV indices (current: %s)",
             value,
         )
         return CalculatedDataPoint(

--- a/ecowitt2mqtt/helpers/calculator/meteo.py
+++ b/ecowitt2mqtt/helpers/calculator/meteo.py
@@ -861,6 +861,10 @@ def calculate_safe_exposure_time(
     try:
         final_value = round((200 * safe_exposure_info.constant) / (3 * value), 1)
     except ZeroDivisionError:
+        LOGGER.debug(
+            "Safe exposure times are only valid for UV indices above 0 (current: %s)",
+            value,
+        )
         return CalculatedDataPoint(
             data_point_key=data_point_key, value=None, unit=TIME_MINUTES
         )


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds a debug log message when safe exposure times can't be calculated (similar to what is done for windchill, simmer index, etc.).

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
