### PR TITLE
Ensure that unhandled exceptions in MQTT loops stop the runtime

### DIFF
--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -63,3 +63,21 @@ async def test_publish_success(
             data=device_data,
         )
         assert resp.status == 204
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "mqtt_publish_side_effect",
+    [AsyncMock(side_effect=Exception("Something horrible happened"))],
+)
+async def test_unknown_exception_shutdown(
+    caplog, device_data, ecowitt, setup_asyncio_mqtt, setup_uvicorn_server
+):
+    """Test that an unknown exception successfully shuts down the runtime."""
+    async with ClientSession() as session:
+        await session.request(
+            "post",
+            f"http://0.0.0.0:{TEST_PORT}{TEST_ENDPOINT}",
+            data=device_data,
+        )
+    assert any(m for m in caplog.messages if "Something horrible happened" in m)


### PR DESCRIPTION
**Describe what the PR does:**

This PR ensures that unhandled exceptions in MQTT loops will (a) be properly logged (including tracebacks) and (b) shut the runtime down (so that the user can more readily know that something bad happened).

**Does this fix a specific issue?**

N/A

**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
