### PR TITLE
Reduce stale timeframe from 90 days to 21 days

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -2,7 +2,7 @@
 # Configuration for probot-stale - https://github.com/probot/stale
 
 # Number of days of inactivity before an Issue or Pull Request becomes stale
-daysUntilStale: 90
+daysUntilStale: 21
 
 # Number of days of inactivity before an Issue or Pull Request with the stale
 # label is closed. Set to false to disable. If disabled, issues still need to


### PR DESCRIPTION
**Describe what the PR does:**

We currently wait 90 days until marking issues as stale, but that's too long. We should strive to prompt more active engagement. So, this PR reduces the wait time to 21 days.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
