### PR TITLE
Allow a trailing slash on the `ecowitt2mqtt` endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,7 @@ Fill out the form with these values and tap `Save`:
 
 * `Protocol Type Same As`: `Ecowitt`
 * `Server IP / Hostname`: the IP address/hostname of the device running `ecowitt2mqtt`
-* `Path`: `/data/report` (note that unlike the default in the WS View App, there shouldn't
-  be a trailing slash)
+* `Path`: `/data/report/`
 * `Port`: `8080` (the default port on which `ecowitt2mqtt` is served)
 * `Upload Interval`: `60` (change this to alter the frequency with which data is published)
 

--- a/ecowitt2mqtt/runtime.py
+++ b/ecowitt2mqtt/runtime.py
@@ -53,11 +53,17 @@ class Runtime:  # pylint: disable=too-many-instance-attributes
             uvicorn_log_level = UVICORN_LOG_LEVEL_ERROR
 
         app = FastAPI()
-        app.post(
+
+        for route in (
             ecowitt.configs.default_config.endpoint,
-            status_code=status.HTTP_204_NO_CONTENT,
-            response_class=Response,
-        )(self._async_post_data)
+            f"{ecowitt.configs.default_config.endpoint}/",
+        ):
+            app.post(
+                route,
+                status_code=status.HTTP_204_NO_CONTENT,
+                response_class=Response,
+            )(self._async_post_data)
+
         self._server = DeSignaledUvicornServer(
             config=uvicorn.Config(
                 app,

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -52,16 +52,19 @@ async def test_publish_failure(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "route",
+    [
+        f"http://0.0.0.0:{TEST_PORT}{TEST_ENDPOINT}",
+        f"http://0.0.0.0:{TEST_PORT}{TEST_ENDPOINT}/",
+    ],
+)
 async def test_publish_success(
-    device_data, ecowitt, setup_asyncio_mqtt, setup_uvicorn_server
+    device_data, ecowitt, route, setup_asyncio_mqtt, setup_uvicorn_server
 ):
     """Test a successful MQTT publish."""
     async with ClientSession() as session:
-        resp = await session.request(
-            "post",
-            f"http://0.0.0.0:{TEST_PORT}{TEST_ENDPOINT}",
-            data=device_data,
-        )
+        resp = await session.request("post", route, data=device_data)
         assert resp.status == 204
 
 


### PR DESCRIPTION
**Describe what the PR does:**

More than one person has run into https://github.com/bachya/ecowitt2mqtt/issues/176 (wherein a trailing slash on the endpoint results in an `HTTP 307` response), so this PR allows the trailing slash to be present or absent (both will work).

**Does this fix a specific issue?**

Fixes https://github.com/bachya/ecowitt2mqtt/issues/176

**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [x] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
