### PR TITLE
Fix publishing of `latest` image to Docker Hub

### DIFF
--- a/.github/workflows/publish_to_docker_hub.yaml
+++ b/.github/workflows/publish_to_docker_hub.yaml
@@ -28,7 +28,7 @@ jobs:
             VERSION=${GITHUB_REF#refs/tags/}
           elif [[ $GITHUB_REF == refs/heads/dev ]]; then
             VERSION=dev
-          elif [[ $GITHUB_REF == refs/heads/master ]]; then
+          elif [[ $GITHUB_REF == refs/heads/main ]]; then
             VERSION=latest
           fi
 


### PR DESCRIPTION
**Describe what the PR does:**

When I moved the default production branch from `master` to `main` in https://github.com/bachya/ecowitt2mqtt/pull/257, I neglected to update the GitHub Action that publishes Docker images to Docker Hub (resulting in the `latest` image being quite out of date). This PR fixes the issue.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
