### PR TITLE
Adjust Docker Hub build action to include PRs

### DIFF
--- a/.github/workflows/publish_to_docker_hub.yaml
+++ b/.github/workflows/publish_to_docker_hub.yaml
@@ -2,6 +2,8 @@
 name: "Publish to Docker Hub"
 
 on:
+  pull_request:
+
   push:
     branches:
       - dev
@@ -18,30 +20,15 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
 
-      - name: Prepare
-        id: prep
-        run: |
-          DOCKER_IMAGE=bachya/ecowitt2mqtt
-          VERSION=noop
-
-          if [[ $GITHUB_REF == refs/tags/* ]]; then
-            VERSION=${GITHUB_REF#refs/tags/}
-          elif [[ $GITHUB_REF == refs/heads/dev ]]; then
-            VERSION=dev
-          elif [[ $GITHUB_REF == refs/heads/main ]]; then
-            VERSION=latest
-          fi
-
-          TAGS="${DOCKER_IMAGE}:${VERSION}"
-          if [[ $VERSION =~ ^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
-            MINOR=${VERSION%.*}
-            MAJOR=${MINOR%.*}
-            TAGS="$TAGS,${DOCKER_IMAGE}:${MINOR},${DOCKER_IMAGE}:${MAJOR},${DOCKER_IMAGE}:latest"
-          fi
-
-          echo ::set-output name=version::${VERSION}
-          echo ::set-output name=tags::${TAGS}
-          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: bachya/ecowitt2mqtt
+          tags: |
+              type=ref,event=branch
+              type=ref,event=pr
+              type=ref,event=tag
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
@@ -63,6 +50,7 @@ jobs:
           context: .
           file: ./Dockerfile
           platforms: >-
-            linux/amd64,linux/arm64
+            linux/amd64,linux/arm/v7,linux/arm64/v8
           push: true
-          tags: ${{ steps.prep.outputs.tags }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish_to_docker_hub.yaml
+++ b/.github/workflows/publish_to_docker_hub.yaml
@@ -12,7 +12,8 @@ on:
       - "*"
 
 jobs:
-  publish_to_docker_hub:
+  publish:
+    name: Publish Images
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/publish_to_docker_hub.yaml
+++ b/.github/workflows/publish_to_docker_hub.yaml
@@ -50,7 +50,7 @@ jobs:
           context: .
           file: ./Dockerfile
           platforms: >-
-            linux/amd64,linux/arm/v7,linux/arm64/v8
+            linux/amd64,linux/arm64/v8
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
**Describe what the PR does:**

This PR updates our Docker Hub workflow to publish images of PRs. This will help in a couple of ways:

1. It'll allow us to update/triage/diagnose Docker issues within a PR (vs. going straight to `dev`).
2. For longer-running PRs, it'll allow Docker users to test the PR changes easily.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
