### PR TITLE
Add `armv7` support to the Docker image

### DIFF
--- a/.github/workflows/publish_to_docker_hub.yaml
+++ b/.github/workflows/publish_to_docker_hub.yaml
@@ -51,7 +51,7 @@ jobs:
           context: .
           file: ./Dockerfile
           platforms: >-
-            linux/arm/v7
+            linux/amd64,linux/arm/v7,linux/arm64/v8
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish_to_docker_hub.yaml
+++ b/.github/workflows/publish_to_docker_hub.yaml
@@ -51,7 +51,7 @@ jobs:
           context: .
           file: ./Dockerfile
           platforms: >-
-            linux/amd64,linux/arm64/v8
+            linux/amd64,linux/arm/v7,linux/arm64/v8
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish_to_docker_hub.yaml
+++ b/.github/workflows/publish_to_docker_hub.yaml
@@ -51,7 +51,8 @@ jobs:
           context: .
           file: ./Dockerfile
           platforms: >-
-            linux/amd64,linux/arm/v7,linux/arm64/v8
+            # linux/amd64,linux/arm/v7,linux/arm64/v8
+            linux/arm/v7
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish_to_docker_hub.yaml
+++ b/.github/workflows/publish_to_docker_hub.yaml
@@ -51,7 +51,7 @@ jobs:
           context: .
           file: ./Dockerfile
           platforms: >-
-            linux/amd64,linux/arm/v7,linux/arm64/v8
+            linux/arm/v7
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish_to_docker_hub.yaml
+++ b/.github/workflows/publish_to_docker_hub.yaml
@@ -51,7 +51,6 @@ jobs:
           context: .
           file: ./Dockerfile
           platforms: >-
-            # linux/amd64,linux/arm/v7,linux/arm64/v8
             linux/arm/v7
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apk add --no-cache \
 
 RUN \
     if [ "$(uname -m)" = "armv7l" ]; then \
-        printf "[global]\nextra-index-url=https://www.piwheels.org/simple\n" > /etc/pip.conf ; \
+        printf "[global]\nextra-index-url=https://www.piwheels.org/simple\n\n" > /etc/pip.conf ; \
     fi
 
 # hadolint ignore=DL3013

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,10 @@ FROM base as builder
 ENV PIP_DEFAULT_TIMEOUT=100 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PIP_NO_CACHE_DIR=1
+
 WORKDIR /app
-# hadolint ignore=DL3018,DL3013
+
+# hadolint ignore=DL3018
 RUN apk add --no-cache \
         bash \
         build-base \
@@ -16,10 +18,15 @@ RUN apk add --no-cache \
         libffi-dev \
         musl-dev \
         openssl-dev \
-        python3-dev \
-    && [ "$(uname -r)" = "armhf" ] \
-        && printf "[global]\nextra-index-url=https://www.piwheels.org/simple\n" > /etc/pip.conf \
-    && python3 -m pip install --upgrade pip \
+        python3-dev
+
+RUN \
+    if [ "$(uname -r)" = "armhf" ]; then \
+        printf "[global]\nextra-index-url=https://www.piwheels.org/simple\n" > /etc/pip.conf ; \
+    fi
+
+# hadolint ignore=DL3013
+RUN python3 -m pip install --upgrade pip \
     && python3 -m pip install cryptography \
     && python3 -m pip install poetry \
     && python3 -m venv /venv

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ RUN apk add --no-cache \
         musl-dev \
         openssl-dev \
         python3-dev \
+    && [ "$(uname -r)" = "armhf" ] \
+        && printf "[global]\nextra-index-url=https://www.piwheels.org/simple\n" > /etc/pip.conf \
     && python3 -m pip install --upgrade pip \
     && python3 -m pip install cryptography \
     && python3 -m pip install poetry \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,19 +18,11 @@ RUN apk add --no-cache \
         libffi-dev \
         musl-dev \
         openssl-dev \
+        py-cryptography \
         python3-dev
 
-RUN \
-    if [ "$(uname -m)" = "armv7l" ]; then \
-        printf "[global]\nextra-index-url=https://www.piwheels.org/simple\n" > /etc/pip.conf ; \
-    fi
-
-RUN cat /etc/pip.conf
-
 # hadolint ignore=DL3013
-RUN python3 -m pip install \
-        cryptography \
-        poetry \
+RUN python3 -m pip install poetry \
     && python3 -m venv /venv
 COPY pyproject.toml ./
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,9 @@ WORKDIR /app
 # hadolint ignore=DL3008
 RUN apt-get update \
     && apt-get upgrade -y \
-    && apt-get install -y --no-install-recommends build-essential
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        libffi-dev
 
 RUN \
     if [ "$(uname -m)" = "armv7l" ]; then \
@@ -33,12 +35,12 @@ RUN poetry build && /venv/bin/python3 -m pip install dist/*.whl
 
 FROM base as final
 WORKDIR /app
-# RUN addgroup -g 1000 -S ecowitt2mqtt \
-#     && adduser -u 1000 -S ecowitt2mqtt -G ecowitt2mqtt
+RUN groupadd -g 1000 ecowitt2mqtt \
+    && useradd ecowitt2mqtt -u 1000 -g 1000
 COPY --from=builder /venv /venv
 ENV PATH="/venv/bin:${PATH}"
 ENV VIRTUAL_ENV="/venv"
 COPY docker-entrypoint.sh /usr/local/bin/
-# RUN chown -R ecowitt2mqtt:ecowitt2mqtt ${VIRTUAL_ENV} /app /usr/local/bin/docker-entrypoint.sh
-# USER 1000
+RUN chown -R ecowitt2mqtt:ecowitt2mqtt ${VIRTUAL_ENV} /app /usr/local/bin/docker-entrypoint.sh
+USER 1000
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,8 @@ RUN \
         printf "[global]\nextra-index-url=https://www.piwheels.org/simple\n" > /etc/pip.conf ; \
     fi
 
+RUN cat /etc/pip.conf
+
 # hadolint ignore=DL3013
 RUN python3 -m pip install \
         cryptography \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,17 +14,22 @@ WORKDIR /app
 RUN apk add --no-cache \
         bash \
         build-base \
-        cargo \
         gcc \
         libffi-dev \
         musl-dev \
         openssl-dev \
-        python3-dev
+        python3-dev \
+    && apk del --purge py-cryptography
+
+RUN \
+    if [ "$(uname -m)" = "armv7l" ]; then \
+        printf "[global]\nextra-index-url=https://www.piwheels.org/simple\n" > /etc/pip.conf ; \
+    fi
 
 # hadolint ignore=DL3013
 RUN python3 -m pip install --upgrade pip \
-    && python3 -m pip install cryptography \
-    && python3 -m pip install poetry \
+    && python3 -m pip -v install cryptography \
+    && python3 -m pip -v install poetry \
     && python3 -m venv /venv
 COPY pyproject.toml ./
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,15 +20,11 @@ RUN apk add --no-cache \
         openssl-dev \
         python3-dev
 
-RUN \
-    if [ "$(uname -m)" = "armv7l" ]; then \
-        printf "[global]\nextra-index-url=https://www.piwheels.org/simple\n\n" > /etc/pip.conf ; \
-    fi
-
 # hadolint ignore=DL3013
 RUN python3 -m pip install --upgrade pip \
-    && python3 -m pip install cryptography \
-    && python3 -m pip install poetry \
+    && python3 -m pip install --extra-index-url https://www.piwheels.hostedpi.com/simple \
+        cryptography \
+        poetry \
     && python3 -m venv /venv
 COPY pyproject.toml ./
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV PIP_DEFAULT_TIMEOUT=100 \
 
 WORKDIR /app
 
-RUN uname -r
+RUN uname -m
 # hadolint ignore=DL3018,DL3059
 RUN apk add --no-cache \
         bash \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN apk add --no-cache \
         python3-dev
 
 RUN \
-    if [ "$(uname -r)" = "armhf" ]; then \
+    if [ "$(uname -r)" = "armv7l" ]; then \
         printf "[global]\nextra-index-url=https://www.piwheels.org/simple\n" > /etc/pip.conf ; \
     fi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,15 +11,15 @@ ENV PIP_DEFAULT_TIMEOUT=100 \
 WORKDIR /app
 
 RUN uname -r
-# # hadolint ignore=DL3018
-# RUN apk add --no-cache \
-#         bash \
-#         build-base \
-#         gcc \
-#         libffi-dev \
-#         musl-dev \
-#         openssl-dev \
-#         python3-dev
+# hadolint ignore=DL3018,DL3059
+RUN apk add --no-cache \
+        bash \
+        build-base \
+        gcc \
+        libffi-dev \
+        musl-dev \
+        openssl-dev \
+        python3-dev
 
 # RUN \
 #     if [ "$(uname -r)" = "armv7l" ]; then \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,15 +14,17 @@ WORKDIR /app
 RUN apk add --no-cache \
         bash \
         build-base \
+        cargo \
         gcc \
         libffi-dev \
         musl-dev \
         openssl-dev \
-        py-cryptography \
         python3-dev
 
 # hadolint ignore=DL3013
-RUN python3 -m pip install poetry \
+RUN python3 -m pip install --upgrade pip \
+    && python3 -m pip install cryptography \
+    && python3 -m pip install poetry \
     && python3 -m venv /venv
 COPY pyproject.toml ./
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,8 @@ RUN apk add --no-cache \
 
 # hadolint ignore=DL3013
 RUN python3 -m pip install --upgrade pip \
-    && python3 -m pip install --extra-index-url https://www.piwheels.hostedpi.com/simple \
-        cryptography \
-        poetry \
+    && python3 -m pip install cryptography –index-url https://www.piwheels.hostedpi.com/simple \
+    && python3 -m pip install poetry \
     && python3 -m venv /venv
 COPY pyproject.toml ./
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,41 +10,42 @@ ENV PIP_DEFAULT_TIMEOUT=100 \
 
 WORKDIR /app
 
-# hadolint ignore=DL3018
-RUN apk add --no-cache \
-        bash \
-        build-base \
-        gcc \
-        libffi-dev \
-        musl-dev \
-        openssl-dev \
-        python3-dev
+RUN uname -r
+# # hadolint ignore=DL3018
+# RUN apk add --no-cache \
+#         bash \
+#         build-base \
+#         gcc \
+#         libffi-dev \
+#         musl-dev \
+#         openssl-dev \
+#         python3-dev
 
-RUN \
-    if [ "$(uname -r)" = "armv7l" ]; then \
-        printf "[global]\nextra-index-url=https://www.piwheels.org/simple\n" > /etc/pip.conf ; \
-    fi
+# RUN \
+#     if [ "$(uname -r)" = "armv7l" ]; then \
+#         printf "[global]\nextra-index-url=https://www.piwheels.org/simple\n" > /etc/pip.conf ; \
+#     fi
 
-# hadolint ignore=DL3013
-RUN python3 -m pip install --upgrade pip \
-    && python3 -m pip install cryptography \
-    && python3 -m pip install poetry \
-    && python3 -m venv /venv
-COPY pyproject.toml ./
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN poetry lock && poetry export --without-hashes -f requirements.txt \
-       | /venv/bin/pip install -r /dev/stdin
-COPY . .
-RUN poetry build && /venv/bin/python3 -m pip install dist/*.whl
+# # hadolint ignore=DL3013
+# RUN python3 -m pip install --upgrade pip \
+#     && python3 -m pip install cryptography \
+#     && python3 -m pip install poetry \
+#     && python3 -m venv /venv
+# COPY pyproject.toml ./
+# SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+# RUN poetry lock && poetry export --without-hashes -f requirements.txt \
+#        | /venv/bin/pip install -r /dev/stdin
+# COPY . .
+# RUN poetry build && /venv/bin/python3 -m pip install dist/*.whl
 
-FROM base as final
-WORKDIR /app
-RUN addgroup -g 1000 -S ecowitt2mqtt \
-    && adduser -u 1000 -S ecowitt2mqtt -G ecowitt2mqtt
-COPY --from=builder /venv /venv
-ENV PATH="/venv/bin:${PATH}"
-ENV VIRTUAL_ENV="/venv"
-COPY docker-entrypoint.sh /usr/local/bin/
-RUN chown -R ecowitt2mqtt:ecowitt2mqtt ${VIRTUAL_ENV} /app /usr/local/bin/docker-entrypoint.sh
-USER 1000
-ENTRYPOINT ["docker-entrypoint.sh"]
+# FROM base as final
+# WORKDIR /app
+# RUN addgroup -g 1000 -S ecowitt2mqtt \
+#     && adduser -u 1000 -S ecowitt2mqtt -G ecowitt2mqtt
+# COPY --from=builder /venv /venv
+# ENV PATH="/venv/bin:${PATH}"
+# ENV VIRTUAL_ENV="/venv"
+# COPY docker-entrypoint.sh /usr/local/bin/
+# RUN chown -R ecowitt2mqtt:ecowitt2mqtt ${VIRTUAL_ENV} /app /usr/local/bin/docker-entrypoint.sh
+# USER 1000
+# ENTRYPOINT ["docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,9 @@ WORKDIR /app
 # hadolint ignore=DL3008
 RUN apt-get update \
     && apt-get upgrade -y \
-    && apt-get install -y --no-install-recommends build-essential
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        libffi-dev
 
 RUN \
     if [ "$(dpkg --print-architecture)" = "armhf" ]; then \
@@ -22,12 +24,7 @@ RUN \
 
 # hadolint ignore=DL3013
 RUN python3 -m pip install --upgrade pip \
-    && python3 -m pip install \
-        cffi \
-        cryptography \
-        dulwich \
-        msgpack \
-        pyrsistent \
+    && python3 -m pip install cryptography \
     && python3 -m pip install poetry \
     && python3 -m venv /venv
 COPY pyproject.toml ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,7 @@ ENV PIP_DEFAULT_TIMEOUT=100 \
 
 WORKDIR /app
 
-RUN uname -m
-# hadolint ignore=DL3018,DL3059
+# hadolint ignore=DL3018
 RUN apk add --no-cache \
         bash \
         build-base \
@@ -21,31 +20,31 @@ RUN apk add --no-cache \
         openssl-dev \
         python3-dev
 
-# RUN \
-#     if [ "$(uname -r)" = "armv7l" ]; then \
-#         printf "[global]\nextra-index-url=https://www.piwheels.org/simple\n" > /etc/pip.conf ; \
-#     fi
+RUN \
+    if [ "$(uname -m)" = "armv7l" ]; then \
+        printf "[global]\nextra-index-url=https://www.piwheels.org/simple\n" > /etc/pip.conf ; \
+    fi
 
-# # hadolint ignore=DL3013
-# RUN python3 -m pip install --upgrade pip \
-#     && python3 -m pip install cryptography \
-#     && python3 -m pip install poetry \
-#     && python3 -m venv /venv
-# COPY pyproject.toml ./
-# SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-# RUN poetry lock && poetry export --without-hashes -f requirements.txt \
-#        | /venv/bin/pip install -r /dev/stdin
-# COPY . .
-# RUN poetry build && /venv/bin/python3 -m pip install dist/*.whl
+# hadolint ignore=DL3013
+RUN python3 -m pip install --upgrade pip \
+    && python3 -m pip install cryptography \
+    && python3 -m pip install poetry \
+    && python3 -m venv /venv
+COPY pyproject.toml ./
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN poetry lock && poetry export --without-hashes -f requirements.txt \
+       | /venv/bin/pip install -r /dev/stdin
+COPY . .
+RUN poetry build && /venv/bin/python3 -m pip install dist/*.whl
 
-# FROM base as final
-# WORKDIR /app
-# RUN addgroup -g 1000 -S ecowitt2mqtt \
-#     && adduser -u 1000 -S ecowitt2mqtt -G ecowitt2mqtt
-# COPY --from=builder /venv /venv
-# ENV PATH="/venv/bin:${PATH}"
-# ENV VIRTUAL_ENV="/venv"
-# COPY docker-entrypoint.sh /usr/local/bin/
-# RUN chown -R ecowitt2mqtt:ecowitt2mqtt ${VIRTUAL_ENV} /app /usr/local/bin/docker-entrypoint.sh
-# USER 1000
-# ENTRYPOINT ["docker-entrypoint.sh"]
+FROM base as final
+WORKDIR /app
+RUN addgroup -g 1000 -S ecowitt2mqtt \
+    && adduser -u 1000 -S ecowitt2mqtt -G ecowitt2mqtt
+COPY --from=builder /venv /venv
+ENV PATH="/venv/bin:${PATH}"
+ENV VIRTUAL_ENV="/venv"
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN chown -R ecowitt2mqtt:ecowitt2mqtt ${VIRTUAL_ENV} /app /usr/local/bin/docker-entrypoint.sh
+USER 1000
+ENTRYPOINT ["docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,7 @@ RUN apk add --no-cache \
         libffi-dev \
         musl-dev \
         openssl-dev \
-        python3-dev \
-    && apk del --purge py-cryptography
+        python3-dev
 
 RUN \
     if [ "$(uname -m)" = "armv7l" ]; then \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apk add --no-cache \
 
 RUN \
     if [ "$(uname -m)" = "armv7l" ]; then \
-        printf "[global]\nextra-index-url=https://www.piwheels.org/simple\n\n" > /etc/pip.conf ; \
+        printf "[global]\nextra-index-url=https://www.piwheels.org/simple\n" > /etc/pip.conf ; \
     fi
 
 # hadolint ignore=DL3013

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,17 +13,21 @@ WORKDIR /app
 # hadolint ignore=DL3008
 RUN apt-get update \
     && apt-get upgrade -y \
-    && apt-get install -y --no-install-recommends \
-        build-essential \
-        libffi-dev
+    && apt-get install -y --no-install-recommends build-essential
 
 RUN \
-    if [ "$(uname -m)" = "armv7l" ]; then \
+    if [ "$(dpkg --print-architecture)" = "armhf" ]; then \
         printf "[global]\nextra-index-url=https://www.piwheels.org/simple\n" > /etc/pip.conf ; \
     fi
 
 # hadolint ignore=DL3013
 RUN python3 -m pip install --upgrade pip \
+    && python3 -m pip install \
+        cffi \
+        cryptography \
+        dulwich \
+        msgpack \
+        pyrsistent \
     && python3 -m pip install poetry \
     && python3 -m venv /venv
 COPY pyproject.toml ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,15 @@ RUN apk add --no-cache \
         openssl-dev \
         python3-dev
 
+RUN \
+    if [ "$(uname -m)" = "armv7l" ]; then \
+        printf "[global]\nextra-index-url=https://www.piwheels.org/simple\n\n" > /etc/pip.conf ; \
+    fi
+
 # hadolint ignore=DL3013
-RUN python3 -m pip install --upgrade pip \
-    && python3 -m pip install cryptography –index-url https://www.piwheels.hostedpi.com/simple \
-    && python3 -m pip install poetry \
+RUN python3 -m pip install \
+        cryptography \
+        poetry \
     && python3 -m venv /venv
 COPY pyproject.toml ./
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-alpine as base
+FROM python:3.10-slim-bullseye as base
 ENV PYTHONFAULTHANDLER=1 \
     PYTHONHASHSEED=random \
     PYTHONUNBUFFERED=1
@@ -10,15 +10,10 @@ ENV PIP_DEFAULT_TIMEOUT=100 \
 
 WORKDIR /app
 
-# hadolint ignore=DL3018
-RUN apk add --no-cache \
-        bash \
-        build-base \
-        gcc \
-        libffi-dev \
-        musl-dev \
-        openssl-dev \
-        python3-dev
+# hadolint ignore=DL3008
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends build-essential
 
 RUN \
     if [ "$(uname -m)" = "armv7l" ]; then \
@@ -27,8 +22,7 @@ RUN \
 
 # hadolint ignore=DL3013
 RUN python3 -m pip install --upgrade pip \
-    && python3 -m pip -v install cryptography \
-    && python3 -m pip -v install poetry \
+    && python3 -m pip install poetry \
     && python3 -m venv /venv
 COPY pyproject.toml ./
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,12 +33,12 @@ RUN poetry build && /venv/bin/python3 -m pip install dist/*.whl
 
 FROM base as final
 WORKDIR /app
-RUN addgroup -g 1000 -S ecowitt2mqtt \
-    && adduser -u 1000 -S ecowitt2mqtt -G ecowitt2mqtt
+# RUN addgroup -g 1000 -S ecowitt2mqtt \
+#     && adduser -u 1000 -S ecowitt2mqtt -G ecowitt2mqtt
 COPY --from=builder /venv /venv
 ENV PATH="/venv/bin:${PATH}"
 ENV VIRTUAL_ENV="/venv"
 COPY docker-entrypoint.sh /usr/local/bin/
-RUN chown -R ecowitt2mqtt:ecowitt2mqtt ${VIRTUAL_ENV} /app /usr/local/bin/docker-entrypoint.sh
-USER 1000
+# RUN chown -R ecowitt2mqtt:ecowitt2mqtt ${VIRTUAL_ENV} /app /usr/local/bin/docker-entrypoint.sh
+# USER 1000
 ENTRYPOINT ["docker-entrypoint.sh"]


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds `armv7` support back to the Docker image. Note that building this image will be fairly slow: I tried every possible way to use a pre-built `cryptography` wheel from piwheels.org, but nothing worked, so it needs to be compiled.

**Does this fix a specific issue?**

Fixes https://github.com/bachya/ecowitt2mqtt/issues/289

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
