### PR TITLE
Fix unhandled KeyError related to the HASS MQTT Discovery prefix

### DIFF
--- a/ecowitt2mqtt/config.py
+++ b/ecowitt2mqtt/config.py
@@ -175,9 +175,9 @@ class Config:  # pylint: disable=too-many-public-methods
         return cast(bool, self._config.get(CONF_HASS_DISCOVERY))
 
     @property
-    def hass_discovery_prefix(self) -> str:
+    def hass_discovery_prefix(self) -> str | None:
         """Return the Home Assistant Discovery MQTT prefix."""
-        return cast(str, self._config[CONF_HASS_DISCOVERY_PREFIX])
+        return self._config.get(CONF_HASS_DISCOVERY_PREFIX)
 
     @property
     def hass_entity_id_prefix(self) -> str | None:


### PR DESCRIPTION
**Describe what the PR does:**

Our current voluptuous schema might not return a HASS MQTT Discovery prefix, but our `Config` object will fail if it isn't there. This PR relaxes the requirement. 
**Does this fix a specific issue?**

Fixes https://github.com/bachya/ecowitt2mqtt/issues/297

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
