### PR TITLE
Fix improper use of HASS publisher

### DIFF
--- a/ecowitt2mqtt/config.py
+++ b/ecowitt2mqtt/config.py
@@ -58,6 +58,7 @@ HASS_DISCOVERY_SCHEMA = vol.Schema(
 MQTT_TOPIC_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_MQTT_TOPIC): str,
+        vol.Optional(CONF_HASS_DISCOVERY, default=False): vol.All(cv.boolean, False),
     },
     extra=vol.ALLOW_EXTRA,
 )


### PR DESCRIPTION
**Describe what the PR does:**

In the rare case where a user provides the `ECOWITT2MQTT_HASS_DISCOVERY` variable with a value of `False`, we still end up using the HASS publisher because the string value `"false"` doesn't get parsed correctly. This PR fixes the bug.

**Does this fix a specific issue?**

Fixes https://github.com/bachya/ecowitt2mqtt/issues/299

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
