### PR TITLE
Add TemperatureConverter helper

### DIFF
--- a/ecowitt2mqtt/const.py
+++ b/ecowitt2mqtt/const.py
@@ -211,6 +211,7 @@ SPEED_MILLIMETERS_PER_DAY: Final = "mm/d"
 # Temperature units:
 TEMP_CELSIUS: Final = "°C"
 TEMP_FAHRENHEIT: Final = "°F"
+TEMP_KELVIN: Final = "K"
 
 # Time units
 TIME_MINUTES: Final = "min"

--- a/tests/util/test_unit_conversion.py
+++ b/tests/util/test_unit_conversion.py
@@ -1,7 +1,11 @@
 """Test unit conversion helpers."""
 import pytest
 
-from ecowitt2mqtt.util.unit_conversion import SpeedConverter, UnitConversionError
+from ecowitt2mqtt.util.unit_conversion import (
+    SpeedConverter,
+    TemperatureConverter,
+    UnitConversionError,
+)
 
 
 @pytest.mark.parametrize(
@@ -9,6 +13,8 @@ from ecowitt2mqtt.util.unit_conversion import SpeedConverter, UnitConversionErro
     [
         ("speed", SpeedConverter, "mph", "km/s"),
         ("speed", SpeedConverter, "km/d", "m/s"),
+        ("temperature", TemperatureConverter, "°C", "Bolts"),
+        ("temperature", TemperatureConverter, "Fake", "°C"),
     ],
 )
 def test_invalid_units(converter, from_unit, to_unit, unit_class):
@@ -36,3 +42,20 @@ def test_invalid_units(converter, from_unit, to_unit, unit_class):
 def test_speed_conversion(converted_value, from_unit, to_unit, value):
     """Test speed conversions."""
     assert SpeedConverter.convert(value, from_unit, to_unit) == converted_value
+
+
+@pytest.mark.parametrize(
+    "value,from_unit,to_unit,converted_value",
+    [
+        (20, "°C", "°C", 20.0),
+        (20, "°C", "°F", 68.0),
+        (10, "°C", "K", 283.15),
+        (80, "°F", "°C", 26.666666666666664),
+        (70, "°F", "K", 294.26111111111106),
+        (200, "K", "°C", -73.14999999999998),
+        (350, "K", "°F", 170.33000000000004),
+    ],
+)
+def test_temperature_conversion(converted_value, from_unit, to_unit, value):
+    """Test temperature conversions."""
+    assert TemperatureConverter.convert(value, from_unit, to_unit) == converted_value


### PR DESCRIPTION
**Describe what the PR does:**

In support of https://github.com/bachya/ecowitt2mqtt/issues/308, this PR adds another `BaseUnitConverter` subclass: `TemperatureConverter`. In the future, this building block will allow conversion to/from a larger variety of temperature-related units:

* `°C` (Metric)
* `°F` (Imperial)
* `K`

Thanks to Home Assistant for [the initial work and inspiration](https://github.com/home-assistant/core/blob/dev/homeassistant/util/unit_conversion.py).

**Does this fix a specific issue?**

N/A

**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
