### PR TITLE
Add PressureConverter helper

### DIFF
--- a/ecowitt2mqtt/const.py
+++ b/ecowitt2mqtt/const.py
@@ -195,8 +195,15 @@ CONCENTRATION_MICROGRAMS_PER_CUBIC_METER: Final = "µg/m³"
 CONCENTRATION_PARTS_PER_MILLION: Final = "ppm"
 
 # Pressure units:
+PRESSURE_BAR: Final = "bar"
+PRESSURE_CBAR: Final = "cbar"
 PRESSURE_HPA: Final = "hPa"
 PRESSURE_INHG: Final = "inHg"
+PRESSURE_KPA: Final = "kPa"
+PRESSURE_MBAR: Final = "mbar"
+PRESSURE_MMHG: Final = "mmHg"
+PRESSURE_PA: Final = "Pa"
+PRESSURE_PSI: Final = "psi"
 
 # Speed units:
 SPEED_FEET_PER_SECOND: Final = "ft/s"

--- a/ecowitt2mqtt/util/unit_conversion.py
+++ b/ecowitt2mqtt/util/unit_conversion.py
@@ -4,6 +4,15 @@ from __future__ import annotations
 from typing import Final
 
 from ecowitt2mqtt.const import (
+    PRESSURE_BAR,
+    PRESSURE_CBAR,
+    PRESSURE_HPA,
+    PRESSURE_INHG,
+    PRESSURE_KPA,
+    PRESSURE_MBAR,
+    PRESSURE_MMHG,
+    PRESSURE_PA,
+    PRESSURE_PSI,
     SPEED_FEET_PER_SECOND,
     SPEED_INCHES_PER_DAY,
     SPEED_INCHES_PER_HOUR,
@@ -33,6 +42,10 @@ _NAUTICAL_MILE_TO_M = 1852
 # Duration conversion constants:
 _HRS_TO_SECS = 60 * 60
 _DAYS_TO_SECS = _HRS_TO_SECS * 24
+
+# Pressure conversion constants:
+_STANDARD_GRAVITY = 9.80665
+_MERCURY_DENSITY = 13.5951
 
 UNIT_NOT_RECOGNIZED_TEMPLATE: Final = '"{}" is not a recognized {} unit'
 
@@ -71,8 +84,38 @@ class BaseUnitConverter:
         return new_value * to_ratio
 
 
+class PressureConverter(BaseUnitConverter):
+    """Define a utility to convert pressure values."""
+
+    UNIT_CLASS = "pressure"
+    NORMALIZED_UNIT = PRESSURE_PA
+    VALID_UNITS = {
+        PRESSURE_BAR,
+        PRESSURE_CBAR,
+        PRESSURE_HPA,
+        PRESSURE_INHG,
+        PRESSURE_KPA,
+        PRESSURE_MBAR,
+        PRESSURE_MMHG,
+        PRESSURE_PA,
+        PRESSURE_PSI,
+    }
+
+    _UNIT_CONVERSION = {
+        PRESSURE_BAR: 1 / 100000,
+        PRESSURE_CBAR: 1 / 1000,
+        PRESSURE_HPA: 1 / 100,
+        PRESSURE_INHG: 1 / (_IN_TO_M * 1000 * _STANDARD_GRAVITY * _MERCURY_DENSITY),
+        PRESSURE_KPA: 1 / 1000,
+        PRESSURE_MBAR: 1 / 100,
+        PRESSURE_MMHG: 1 / (_MM_TO_M * 1000 * _STANDARD_GRAVITY * _MERCURY_DENSITY),
+        PRESSURE_PA: 1,
+        PRESSURE_PSI: 1 / 6894.757,
+    }
+
+
 class SpeedConverter(BaseUnitConverter):
-    """Utility to convert speed values."""
+    """Define a utility to convert speed values."""
 
     UNIT_CLASS = "speed"
     NORMALIZED_UNIT = SPEED_METERS_PER_SECOND
@@ -87,7 +130,7 @@ class SpeedConverter(BaseUnitConverter):
         SPEED_MILLIMETERS_PER_DAY,
     }
 
-    _UNIT_CONVERSION: dict[str, float] = {
+    _UNIT_CONVERSION = {
         SPEED_FEET_PER_SECOND: 1 / _FOOT_TO_M,
         SPEED_INCHES_PER_DAY: _DAYS_TO_SECS / _IN_TO_M,
         SPEED_INCHES_PER_HOUR: _HRS_TO_SECS / _IN_TO_M,
@@ -100,7 +143,7 @@ class SpeedConverter(BaseUnitConverter):
 
 
 class TemperatureConverter(BaseUnitConverter):
-    """Utility to convert temperature values."""
+    """Define a utility to convert temperature values."""
 
     UNIT_CLASS = "temperature"
     NORMALIZED_UNIT = TEMP_CELSIUS

--- a/tests/util/test_unit_conversion.py
+++ b/tests/util/test_unit_conversion.py
@@ -2,6 +2,7 @@
 import pytest
 
 from ecowitt2mqtt.util.unit_conversion import (
+    PressureConverter,
     SpeedConverter,
     TemperatureConverter,
     UnitConversionError,
@@ -11,6 +12,8 @@ from ecowitt2mqtt.util.unit_conversion import (
 @pytest.mark.parametrize(
     "unit_class,converter,from_unit,to_unit",
     [
+        ("pressure", PressureConverter, "hPa", "hPa/s"),
+        ("pressure", PressureConverter, "units", "hPa"),
         ("speed", SpeedConverter, "mph", "km/s"),
         ("speed", SpeedConverter, "km/d", "m/s"),
         ("temperature", TemperatureConverter, "°C", "Bolts"),
@@ -22,6 +25,26 @@ def test_invalid_units(converter, from_unit, to_unit, unit_class):
     with pytest.raises(UnitConversionError) as err:
         _ = converter.convert(10, from_unit, to_unit)
         assert f"is not a recognized {unit_class} unit" in str(err)
+
+
+@pytest.mark.parametrize(
+    "value,from_unit,to_unit,converted_value",
+    [
+        (10, "bar", "Pa", 999999.9999999999),
+        (10, "cbar", "Pa", 10000.0),
+        (10, "hPa", "Pa", 1000.0),
+        (10, "inHg", "Pa", 33863.88640341),
+        (10, "kPa", "Pa", 10000.0),
+        (10, "mbar", "Pa", 1000.0),
+        (10, "mmHg", "Pa", 1333.22387415),
+        (10, "Pa", "Pa", 10.0),
+        (10, "Pa", "psi", 0.0014503774389728313),
+        (10, "inHg", "cbar", 33.86388640341),
+    ],
+)
+def test_pressure_conversion(converted_value, from_unit, to_unit, value):
+    """Test pressure conversions."""
+    assert PressureConverter.convert(value, from_unit, to_unit) == converted_value
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**Describe what the PR does:**

In support of https://github.com/bachya/ecowitt2mqtt/issues/308, this PR adds another `BaseUnitConverter` subclass: `PressureConverter`. In the future, this building block will allow conversion to/from a larger variety of pressure-related units:

* `Pa` (Metric)
* `bar` (Metric)
* `cbar` (Metric)
* `hPa` (Metric)
* `inHg` (Imperial)
* `kPa` (Metric)
* `mbar` (Metric)
* `mmHg` (Metric)
* `psi` (Imperial)

Thanks to Home Assistant for [the initial work and inspiration](https://github.com/home-assistant/core/blob/dev/homeassistant/util/unit_conversion.py).

**Does this fix a specific issue?**

N/A

**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
