### PR TITLE
Add DistanceConverter helper

### DIFF
--- a/ecowitt2mqtt/const.py
+++ b/ecowitt2mqtt/const.py
@@ -32,7 +32,6 @@ CONF_PORT: Final = "port"
 CONF_RAW_DATA: Final = "raw_data"
 CONF_VERBOSE: Final = "verbose"
 
-
 # Data points (glob):
 DATA_POINT_GLOB_BAROM: Final = "barom"
 DATA_POINT_GLOB_BATT: Final = "batt"
@@ -171,15 +170,21 @@ UNIT_SYSTEMS: Final = [UNIT_SYSTEM_IMPERIAL, UNIT_SYSTEM_METRIC]
 # Degree units
 DEGREE: Final = "°"
 
-# Distance units:
-DISTANCE_KILOMETERS: Final = "km"
-DISTANCE_MILES: Final = "mi"
-
 # Electric_potential units:
 ELECTRIC_POTENTIAL_VOLT: Final = "V"
 
 # Irradiation units
 IRRADIATION_WATTS_PER_SQUARE_METER: Final = "W/m²"
+
+# Length units:
+LENGTH_CENTIMETERS: Final = "cm"
+LENGTH_FEET: Final = "ft"
+LENGTH_INCHES: Final = "in"
+LENGTH_KILOMETERS: Final = "km"
+LENGTH_METERS: Final = "m"
+LENGTH_MILES: Final = "mi"
+LENGTH_MILLIMETERS: Final = "mm"
+LENGTH_YARD: Final = "yd"
 
 # Light units:
 LIGHT_LUX: Final = "lx"

--- a/ecowitt2mqtt/helpers/calculator/meteo.py
+++ b/ecowitt2mqtt/helpers/calculator/meteo.py
@@ -18,9 +18,9 @@ from ecowitt2mqtt.const import (
     DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_5,
     DATA_POINT_SAFE_EXPOSURE_TIME_SKIN_TYPE_6,
     DEGREE,
-    DISTANCE_KILOMETERS,
-    DISTANCE_MILES,
     IRRADIATION_WATTS_PER_SQUARE_METER,
+    LENGTH_KILOMETERS,
+    LENGTH_MILES,
     LIGHT_LUX,
     LOGGER,
     PERCENTAGE,
@@ -56,9 +56,9 @@ ABSOLUTE_HUMIDITY_MAP = {
     UNIT_SYSTEM_METRIC: WATER_VAPOR_GRAMS_PER_CUBIC_METER,
 }
 
-DISTANCE_UNIT_MAP = {
-    UNIT_SYSTEM_IMPERIAL: DISTANCE_MILES,
-    UNIT_SYSTEM_METRIC: DISTANCE_KILOMETERS,
+LENGTH_UNIT_MAP = {
+    UNIT_SYSTEM_IMPERIAL: LENGTH_MILES,
+    UNIT_SYSTEM_METRIC: LENGTH_KILOMETERS,
 }
 
 PRESSURE_UNIT_MAP = {
@@ -755,7 +755,7 @@ def calculate_lightning_strike_distance(
     return CalculatedDataPoint(
         data_point_key=data_point_key,
         value=final_value,
-        unit=DISTANCE_UNIT_MAP[config.output_unit_system],
+        unit=LENGTH_UNIT_MAP[config.output_unit_system],
     )
 
 

--- a/ecowitt2mqtt/util/unit_conversion.py
+++ b/ecowitt2mqtt/util/unit_conversion.py
@@ -4,6 +4,14 @@ from __future__ import annotations
 from typing import Final
 
 from ecowitt2mqtt.const import (
+    LENGTH_CENTIMETERS,
+    LENGTH_FEET,
+    LENGTH_INCHES,
+    LENGTH_KILOMETERS,
+    LENGTH_METERS,
+    LENGTH_MILES,
+    LENGTH_MILLIMETERS,
+    LENGTH_YARD,
     PRESSURE_BAR,
     PRESSURE_CBAR,
     PRESSURE_HPA,
@@ -82,6 +90,34 @@ class BaseUnitConverter:
         to_ratio = cls._UNIT_CONVERSION[to_unit]
         new_value = value / from_ratio
         return new_value * to_ratio
+
+
+class DistanceConverter(BaseUnitConverter):
+    """Utility to convert distance values."""
+
+    UNIT_CLASS = "distance"
+    NORMALIZED_UNIT = LENGTH_METERS
+    VALID_UNITS = {
+        LENGTH_KILOMETERS,
+        LENGTH_MILES,
+        LENGTH_FEET,
+        LENGTH_METERS,
+        LENGTH_CENTIMETERS,
+        LENGTH_MILLIMETERS,
+        LENGTH_INCHES,
+        LENGTH_YARD,
+    }
+
+    _UNIT_CONVERSION = {
+        LENGTH_METERS: 1,
+        LENGTH_MILLIMETERS: 1 / _MM_TO_M,
+        LENGTH_CENTIMETERS: 1 / _CM_TO_M,
+        LENGTH_KILOMETERS: 1 / _KM_TO_M,
+        LENGTH_INCHES: 1 / _IN_TO_M,
+        LENGTH_FEET: 1 / _FOOT_TO_M,
+        LENGTH_YARD: 1 / _YARD_TO_M,
+        LENGTH_MILES: 1 / _MILE_TO_M,
+    }
 
 
 class PressureConverter(BaseUnitConverter):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -12,10 +12,10 @@ from ecowitt2mqtt.const import (
     CONF_INPUT_UNIT_SYSTEM,
     CONF_OUTPUT_UNIT_SYSTEM,
     DEGREE,
-    DISTANCE_KILOMETERS,
-    DISTANCE_MILES,
     ELECTRIC_POTENTIAL_VOLT,
     IRRADIATION_WATTS_PER_SQUARE_METER,
+    LENGTH_KILOMETERS,
+    LENGTH_MILES,
     LIGHT_LUX,
     PERCENTAGE,
     PRECIPITATION_INCHES,
@@ -961,7 +961,7 @@ def test_disable_calculated_data(device_data, ecowitt):
         "lightning": CalculatedDataPoint(
             "lightning",
             0.6,
-            unit=DISTANCE_MILES,
+            unit=LENGTH_MILES,
             attributes={},
             data_type=DataPointType.NON_BOOLEAN,
         ),
@@ -1639,7 +1639,7 @@ def test_nonnumeric_value(device_data, ecowitt):
         "lightning": CalculatedDataPoint(
             "lightning",
             0.6,
-            unit=DISTANCE_MILES,
+            unit=LENGTH_MILES,
             attributes={},
             data_type=DataPointType.NON_BOOLEAN,
         ),
@@ -2001,7 +2001,7 @@ def test_nonnumeric_value(device_data, ecowitt):
                 "lightning": CalculatedDataPoint(
                     "lightning",
                     0.6,
-                    unit=DISTANCE_MILES,
+                    unit=LENGTH_MILES,
                     attributes={},
                     data_type=DataPointType.NON_BOOLEAN,
                 ),
@@ -3657,7 +3657,7 @@ def test_nonnumeric_value(device_data, ecowitt):
                 "lightning": CalculatedDataPoint(
                     "lightning",
                     0.6,
-                    unit=DISTANCE_MILES,
+                    unit=LENGTH_MILES,
                     attributes={},
                     data_type=DataPointType.NON_BOOLEAN,
                 ),
@@ -5225,7 +5225,7 @@ def test_unit_conversion_to_imperial(device_data, ecowitt):
         "lightning": CalculatedDataPoint(
             "lightning",
             0.6,
-            unit=DISTANCE_MILES,
+            unit=LENGTH_MILES,
             attributes={},
             data_type=DataPointType.NON_BOOLEAN,
         ),
@@ -5596,7 +5596,7 @@ def test_unit_conversion_to_imperial(device_data, ecowitt):
                 "lightning": CalculatedDataPoint(
                     "lightning",
                     1.0,
-                    unit=DISTANCE_KILOMETERS,
+                    unit=LENGTH_KILOMETERS,
                     attributes={},
                     data_type=DataPointType.NON_BOOLEAN,
                 ),
@@ -6266,7 +6266,7 @@ def test_unknown_battery(device_data, ecowitt):
         "lightning": CalculatedDataPoint(
             "lightning",
             0.6,
-            unit=DISTANCE_MILES,
+            unit=LENGTH_MILES,
             attributes={},
             data_type=DataPointType.NON_BOOLEAN,
         ),

--- a/tests/util/test_unit_conversion.py
+++ b/tests/util/test_unit_conversion.py
@@ -2,6 +2,7 @@
 import pytest
 
 from ecowitt2mqtt.util.unit_conversion import (
+    DistanceConverter,
     PressureConverter,
     SpeedConverter,
     TemperatureConverter,
@@ -12,6 +13,8 @@ from ecowitt2mqtt.util.unit_conversion import (
 @pytest.mark.parametrize(
     "unit_class,converter,from_unit,to_unit",
     [
+        ("distance", DistanceConverter, "miles", "ft"),
+        ("distance", DistanceConverter, "m", "dm"),
         ("pressure", PressureConverter, "hPa", "hPa/s"),
         ("pressure", PressureConverter, "units", "hPa"),
         ("speed", SpeedConverter, "mph", "km/s"),
@@ -25,6 +28,24 @@ def test_invalid_units(converter, from_unit, to_unit, unit_class):
     with pytest.raises(UnitConversionError) as err:
         _ = converter.convert(10, from_unit, to_unit)
         assert f"is not a recognized {unit_class} unit" in str(err)
+
+
+@pytest.mark.parametrize(
+    "value,from_unit,to_unit,converted_value",
+    [
+        (10, "km", "km", 10.0),
+        (10, "km", "mi", 6.21371192237334),
+        (10, "km", "ft", 32808.39895013124),
+        (10, "km", "m", 10000.0),
+        (10, "km", "cm", 1000000.0),
+        (10, "km", "mm", 10000000.0),
+        (10, "km", "in", 393700.78740157484),
+        (10, "km", "yd", 10936.13298337708),
+    ],
+)
+def test_distance_conversion(converted_value, from_unit, to_unit, value):
+    """Test distance conversions."""
+    assert DistanceConverter.convert(value, from_unit, to_unit) == converted_value
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**Describe what the PR does:**

In support of https://github.com/bachya/ecowitt2mqtt/issues/308, this PR adds another `BaseUnitConverter` subclass: `DistanceConverter`. In the future, this building block will allow conversion to/from a larger variety of distance/length-related units:

* `cm` (Metric)
* `ft` (Imperial)
* `in` (Imperial)
* `km` (Metric)
* `m` (Metric)
* `mi` (Imperial)
* `mm` (Metric)
* `yd` (Imperial)

Thanks to Home Assistant for [the initial work and inspiration](https://github.com/home-assistant/core/blob/dev/homeassistant/util/unit_conversion.py).

**Does this fix a specific issue?**

N/A

**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
