### PR TITLE
Add IlluminanceConverter helper

### DIFF
--- a/ecowitt2mqtt/const.py
+++ b/ecowitt2mqtt/const.py
@@ -174,6 +174,10 @@ DEGREE: Final = "°"
 ELECTRIC_POTENTIAL_VOLT: Final = "V"
 
 # Illuminance units:
+ILLUMINANCE_FOOT_CANDLES: Final = "fc"
+ILLUMINANCE_KILOFOOT_CANDLES: Final = "kfc"
+ILLUMINANCE_KILOLUX: Final = "klux"
+ILLUMINANCE_LUX: Final = "lux"
 ILLUMINANCE_WATTS_PER_SQUARE_METER: Final = "W/m²"
 
 # Length units:

--- a/ecowitt2mqtt/util/unit_conversion.py
+++ b/ecowitt2mqtt/util/unit_conversion.py
@@ -4,6 +4,11 @@ from __future__ import annotations
 from typing import Final
 
 from ecowitt2mqtt.const import (
+    ILLUMINANCE_FOOT_CANDLES,
+    ILLUMINANCE_KILOFOOT_CANDLES,
+    ILLUMINANCE_KILOLUX,
+    ILLUMINANCE_LUX,
+    ILLUMINANCE_WATTS_PER_SQUARE_METER,
     LENGTH_CENTIMETERS,
     LENGTH_FEET,
     LENGTH_INCHES,
@@ -40,20 +45,23 @@ from ecowitt2mqtt.const import (
 from ecowitt2mqtt.errors import EcowittError
 
 # Distance conversion constants:
-_MM_TO_M = 0.001
 _CM_TO_M = 0.01
-_KM_TO_M = 1000
-
 _IN_TO_M = 0.0254
+_KM_TO_M = 1000
+_MM_TO_M = 0.001
+_NAUTICAL_MILE_TO_M = 1852
 _FOOT_TO_M = _IN_TO_M * 12
 _YARD_TO_M = _FOOT_TO_M * 3
 _MILE_TO_M = _YARD_TO_M * 1760
 
-_NAUTICAL_MILE_TO_M = 1852
-
 # Duration conversion constants:
 _HRS_TO_SECS = 60 * 60
 _DAYS_TO_SECS = _HRS_TO_SECS * 24
+
+# Illuminance conversion constants:
+_KLUX_TO_LUX = 1000
+_FC_TO_LUX = 10.7639
+_WM2_TO_LUX = 0.0079
 
 # Pressure conversion constants:
 _STANDARD_GRAVITY = 9.80665
@@ -124,6 +132,28 @@ class DistanceConverter(BaseUnitConverter):
     }
 
 
+class IlluminanceConverter(BaseUnitConverter):
+    """Utility to convert illuminance values."""
+
+    UNIT_CLASS = "illuminance"
+    NORMALIZED_UNIT = ILLUMINANCE_LUX
+    VALID_UNITS = {
+        ILLUMINANCE_FOOT_CANDLES,
+        ILLUMINANCE_KILOFOOT_CANDLES,
+        ILLUMINANCE_KILOLUX,
+        ILLUMINANCE_LUX,
+        ILLUMINANCE_WATTS_PER_SQUARE_METER,
+    }
+
+    _UNIT_CONVERSION = {
+        ILLUMINANCE_FOOT_CANDLES: 1 / _FC_TO_LUX,
+        ILLUMINANCE_KILOFOOT_CANDLES: 1 / _FC_TO_LUX / 1000,
+        ILLUMINANCE_KILOLUX: 1 / _KLUX_TO_LUX,
+        ILLUMINANCE_LUX: 1,
+        ILLUMINANCE_WATTS_PER_SQUARE_METER: 1 * _WM2_TO_LUX,
+    }
+
+
 class PrecipitationConverter(BaseUnitConverter):
     """Utility to convert precipitation values."""
 
@@ -138,10 +168,10 @@ class PrecipitationConverter(BaseUnitConverter):
     }
 
     _UNIT_CONVERSION = {
-        PRECIPITATION_MILLIMETERS: 1,
-        PRECIPITATION_MILLIMETERS_PER_HOUR: 1,
         PRECIPITATION_INCHES: 1 * _MM_TO_M / _IN_TO_M,
         PRECIPITATION_INCHES_PER_HOUR: 1 * _MM_TO_M / _IN_TO_M,
+        PRECIPITATION_MILLIMETERS: 1,
+        PRECIPITATION_MILLIMETERS_PER_HOUR: 1,
     }
 
 

--- a/tests/util/test_unit_conversion.py
+++ b/tests/util/test_unit_conversion.py
@@ -3,6 +3,7 @@ import pytest
 
 from ecowitt2mqtt.util.unit_conversion import (
     DistanceConverter,
+    IlluminanceConverter,
     PrecipitationConverter,
     PressureConverter,
     SpeedConverter,
@@ -16,6 +17,8 @@ from ecowitt2mqtt.util.unit_conversion import (
     [
         ("distance", DistanceConverter, "miles", "ft"),
         ("distance", DistanceConverter, "m", "dm"),
+        ("illuminance", IlluminanceConverter, "lux", "bulbs"),
+        ("illuminance", IlluminanceConverter, "sunbeams", "klux"),
         ("precipitation", PrecipitationConverter, "mm/s", "mm/h"),
         ("precipitation", PrecipitationConverter, "in/h", "yd/yr"),
         ("pressure", PressureConverter, "hPa", "hPa/s"),
@@ -49,6 +52,24 @@ def test_invalid_units(converter, from_unit, to_unit, unit_class):
 def test_distance_conversion(converted_value, from_unit, to_unit, value):
     """Test distance conversions."""
     assert DistanceConverter.convert(value, from_unit, to_unit) == converted_value
+
+
+@pytest.mark.parametrize(
+    "value,from_unit,to_unit,converted_value",
+    [
+        (10, "lux", "lux", 10.0),
+        (10, "lux", "fc", 0.9290312990644656),
+        (10, "lux", "kfc", 0.0009290312990644657),
+        (10, "lux", "klux", 0.01),
+        (10, "lux", "W/m²", 0.07900000000000001),
+        (10, "W/m²", "lux", 1265.8227848101264),
+        (10, "fc", "lux", 107.639),
+        (10, "fc", "klux", 0.107639),
+    ],
+)
+def test_illuminance_conversion(converted_value, from_unit, to_unit, value):
+    """Test illuminance conversions."""
+    assert IlluminanceConverter.convert(value, from_unit, to_unit) == converted_value
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**Describe what the PR does:**

In support of https://github.com/bachya/ecowitt2mqtt/issues/308, this PR adds another `BaseUnitConverter` subclass: `IlluminanceConverter`. In the future, this building block will allow conversion to/from a larger variety of illuminance-related units:

* `fc` (Imperial)
* `kfc` (Imperial)
* `lux` (Metric)
* `klux` (Metric)
* `W/m²` (Metric)

Thanks to Home Assistant for [the initial work and inspiration](https://github.com/home-assistant/core/blob/dev/homeassistant/util/unit_conversion.py).

**Does this fix a specific issue?**

N/A

**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
