### PR TITLE
Add `get_unit_ratio` to all `BaseUnitConverter` classes

### DIFF
--- a/ecowitt2mqtt/util/unit_conversion.py
+++ b/ecowitt2mqtt/util/unit_conversion.py
@@ -103,6 +103,11 @@ class BaseUnitConverter:
         new_value = value / from_ratio
         return new_value * to_ratio
 
+    @classmethod
+    def get_unit_ratio(cls, from_unit: str, to_unit: str) -> float:
+        """Get unit ratio between units of measurement."""
+        return cls._UNIT_CONVERSION[from_unit] / cls._UNIT_CONVERSION[to_unit]
+
 
 class DistanceConverter(BaseUnitConverter):
     """Utility to convert distance values."""

--- a/tests/util/test_unit_conversion.py
+++ b/tests/util/test_unit_conversion.py
@@ -143,3 +143,21 @@ def test_speed_conversion(converted_value, from_unit, to_unit, value):
 def test_temperature_conversion(converted_value, from_unit, to_unit, value):
     """Test temperature conversions."""
     assert TemperatureConverter.convert(value, from_unit, to_unit) == converted_value
+
+
+@pytest.mark.parametrize(
+    "converter,from_unit,to_unit,ratio",
+    [
+        (DistanceConverter, "km", "m", 0.001),
+        (DistanceConverter, "mi", "m", 0.000621371192237334),
+        (DistanceConverter, "ft", "m", 3.280839895013124),
+        (DistanceConverter, "m", "m", 1.0),
+        (DistanceConverter, "cm", "m", 100.0),
+        (DistanceConverter, "mm", "m", 1000.0),
+        (DistanceConverter, "in", "m", 39.37007874015748),
+        (DistanceConverter, "yd", "m", 1.093613298337708),
+    ],
+)
+def test_unit_ratio(converter, from_unit, ratio, to_unit):
+    """Test the ratio between two units."""
+    assert converter.get_unit_ratio(from_unit, to_unit) == ratio


### PR DESCRIPTION
**Describe what the PR does:**

In support of https://github.com/bachya/ecowitt2mqtt/issues/308, this PR adds a method to all `BaseUnitConverter` subclasses: `get_unit_ratio`. This is an approximate ratio between two units, and will be useful in scaling precision when converting from a "small" unit to a "big" unit.

Thanks to Home Assistant for [the initial work and inspiration](https://github.com/home-assistant/core/blob/dev/homeassistant/util/unit_conversion.py).

**Does this fix a specific issue?**

N/A

**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
