### PR TITLE
Normalize percentage-based illuminance calculations

### DIFF
--- a/ecowitt2mqtt/helpers/calculator/illuminance.py
+++ b/ecowitt2mqtt/helpers/calculator/illuminance.py
@@ -56,9 +56,7 @@ class IlluminancePerceivedCalculator(BaseIlluminanceCalculator):
     ) -> CalculatedDataPoint:
         """Perform the calculation."""
         solar_rad = cast(float, payload[DATA_POINT_SOLARRADIATION])
-        converted_value = IlluminanceConverter.convert_to_percentage(
-            solar_rad, ILLUMINANCE_WATTS_PER_SQUARE_METER
-        )
+        converted_value = self.convert_value(IlluminanceConverter, solar_rad)
         return self.get_calculated_data_point(converted_value)
 
 

--- a/ecowitt2mqtt/util/unit_conversion.py
+++ b/ecowitt2mqtt/util/unit_conversion.py
@@ -207,18 +207,18 @@ class IlluminanceConverter(BaseUnitConverter):
     }
 
     @classmethod
-    def convert_to_percentage(cls, value: float, from_unit: str) -> float:
-        """Convert an illuminance into a percentage of human-perceived brightness."""
-        lux = cls.convert(value, from_unit, ILLUMINANCE_LUX)
+    def convert(cls, value: float, from_unit: str, to_unit: str) -> float:
+        """Convert one unit of measurement to another."""
+        if to_unit == PERCENTAGE:
+            lux = cls.convert(value, from_unit, ILLUMINANCE_LUX)
+            try:
+                return round(math.log10(lux) / 5, 2) * 100
+            except ValueError:
+                # If we've approached negative infinity, we'll get a math domain error;
+                # in that case, return 0.0:
+                return 0.0
 
-        try:
-            value = round(math.log10(lux) / 5, 2) * 100
-        except ValueError:
-            # If we've approached negative infinity, we'll get a math domain error; in
-            # that case, return 0.0:
-            value = 0.0
-
-        return value
+        return super().convert(value, from_unit, to_unit)
 
 
 class PrecipitationRateConverter(BaseUnitConverter):

--- a/tests/util/test_unit_conversion.py
+++ b/tests/util/test_unit_conversion.py
@@ -61,6 +61,7 @@ def test_distance_conversion(converted_value, from_unit, to_unit, value):
         (10, "W/m²", "lx", 1265.8227848101264),
         (10, "fc", "lx", 107.639),
         (10, "fc", "klx", 0.107639),
+        (264.61, "W/m²", "%", 90.0),
     ],
 )
 def test_illuminance_conversion(converted_value, from_unit, to_unit, value):


### PR DESCRIPTION
**Describe what the PR does:**

The `IlluminanceCalculator` was the one calculator with a special method (calculating percentage brightness). This PR puts that logic into the standard `convert` method, which will enable some other refactorings.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
