### PR TITLE
Refactor and simplify usage of data converters

### DIFF
--- a/ecowitt2mqtt/helpers/calculator/__init__.py
+++ b/ecowitt2mqtt/helpers/calculator/__init__.py
@@ -83,21 +83,22 @@ class Calculator:
     ) -> CalculatedDataPoint:
         """Perform the calculation."""
 
-    def convert_value(
-        self, unit_converter: type[BaseUnitConverter], value: float
-    ) -> float:
-        """Perform the calculation."""
-        assert self.output_unit
-        return unit_converter.convert(value, self.DEFAULT_INPUT_UNIT, self.output_unit)
-
     def get_calculated_data_point(
         self,
         value: CalculatedValueType,
         *,
+        unit_converter: type[BaseUnitConverter] | None = None,
         attributes: dict[str, Any] | None = None,
         data_type: DataPointType | None = None,
     ) -> CalculatedDataPoint:
         """Get the output unit for this calculation."""
+        if unit_converter:
+            assert self.output_unit
+            assert isinstance(value, float)
+            value = unit_converter.convert(
+                value, self.DEFAULT_INPUT_UNIT, self.output_unit
+            )
+
         data_point = CalculatedDataPoint(
             data_point_key=self._data_point_key, value=value, unit=self.output_unit
         )

--- a/ecowitt2mqtt/helpers/calculator/humidity.py
+++ b/ecowitt2mqtt/helpers/calculator/humidity.py
@@ -51,8 +51,7 @@ class AbsoluteHumidityCalculator(Calculator):
         )
 
         value = get_absolute_humidity_in_metric(temp_obj, humidity)
-        converted_value = self.convert_value(VolumeConverter, value)
-        return self.get_calculated_data_point(converted_value)
+        return self.get_calculated_data_point(value, unit_converter=VolumeConverter)
 
 
 class RelativeHumidityCalculator(SimpleCalculator):

--- a/ecowitt2mqtt/helpers/calculator/illuminance.py
+++ b/ecowitt2mqtt/helpers/calculator/illuminance.py
@@ -38,8 +38,9 @@ class IlluminanceLuxCalculator(BaseIlluminanceCalculator):
     ) -> CalculatedDataPoint:
         """Perform the calculation."""
         solar_rad = cast(float, payload[DATA_POINT_SOLARRADIATION])
-        converted_value = self.convert_value(IlluminanceConverter, solar_rad)
-        return self.get_calculated_data_point(converted_value)
+        return self.get_calculated_data_point(
+            solar_rad, unit_converter=IlluminanceConverter
+        )
 
 
 class IlluminancePerceivedCalculator(BaseIlluminanceCalculator):
@@ -56,8 +57,9 @@ class IlluminancePerceivedCalculator(BaseIlluminanceCalculator):
     ) -> CalculatedDataPoint:
         """Perform the calculation."""
         solar_rad = cast(float, payload[DATA_POINT_SOLARRADIATION])
-        converted_value = self.convert_value(IlluminanceConverter, solar_rad)
-        return self.get_calculated_data_point(converted_value)
+        return self.get_calculated_data_point(
+            solar_rad, unit_converter=IlluminanceConverter
+        )
 
 
 class IlluminanceWM2Calculator(SimpleCalculator):

--- a/ecowitt2mqtt/helpers/calculator/lightning.py
+++ b/ecowitt2mqtt/helpers/calculator/lightning.py
@@ -45,6 +45,4 @@ class LightningStrikeDistanceCalculator(Calculator):
         if isinstance(value, str):
             LOGGER.debug("Can't convert value to number: %s", value)
             return self.get_calculated_data_point(None)
-
-        converted_value = self.convert_value(DistanceConverter, value)
-        return self.get_calculated_data_point(converted_value)
+        return self.get_calculated_data_point(value, unit_converter=DistanceConverter)

--- a/ecowitt2mqtt/helpers/calculator/precipitation.py
+++ b/ecowitt2mqtt/helpers/calculator/precipitation.py
@@ -35,8 +35,9 @@ class AccumulatedPrecipitationCalculator(Calculator):
     ) -> CalculatedDataPoint:
         """Perform the calculation."""
         assert isinstance(value, float)
-        converted_value = self.convert_value(AccumulatedPrecipitationConverter, value)
-        return self.get_calculated_data_point(converted_value)
+        return self.get_calculated_data_point(
+            value, unit_converter=AccumulatedPrecipitationConverter
+        )
 
 
 class PrecipitationRateCalculator(Calculator):
@@ -59,5 +60,6 @@ class PrecipitationRateCalculator(Calculator):
     ) -> CalculatedDataPoint:
         """Perform the calculation."""
         assert isinstance(value, float)
-        converted_value = self.convert_value(PrecipitationRateConverter, value)
-        return self.get_calculated_data_point(converted_value)
+        return self.get_calculated_data_point(
+            value, unit_converter=PrecipitationRateConverter
+        )

--- a/ecowitt2mqtt/helpers/calculator/pressure.py
+++ b/ecowitt2mqtt/helpers/calculator/pressure.py
@@ -27,5 +27,4 @@ class PressureCalculator(Calculator):
     ) -> CalculatedDataPoint:
         """Perform the calculation."""
         assert isinstance(value, float)
-        converted_value = self.convert_value(PressureConverter, value)
-        return self.get_calculated_data_point(converted_value)
+        return self.get_calculated_data_point(value, unit_converter=PressureConverter)

--- a/ecowitt2mqtt/helpers/calculator/temperature.py
+++ b/ecowitt2mqtt/helpers/calculator/temperature.py
@@ -174,7 +174,7 @@ THERMAL_PERCEPTION_RATINGS: list[ThermalPerceptionRating] = [
 ]
 
 
-class TemperatureUnitConverter(Calculator):
+class BaseTemperatureCalculator(Calculator):
     """Define a base temperature calculator."""
 
     DEFAULT_INPUT_UNIT = TEMP_FAHRENHEIT
@@ -190,7 +190,7 @@ class TemperatureUnitConverter(Calculator):
         return TEMP_CELSIUS
 
 
-class DewPointCalculator(TemperatureUnitConverter):
+class DewPointCalculator(BaseTemperatureCalculator):
     """Define a dew point calculator."""
 
     @Calculator.requires_keys(DATA_POINT_TEMP, DATA_POINT_HUMIDITY)
@@ -205,11 +205,12 @@ class DewPointCalculator(TemperatureUnitConverter):
             temp, humidity, self._config.input_unit_system
         )
 
-        converted_value = self.convert_value(TemperatureConverter, dew_point_obj.f)
-        return self.get_calculated_data_point(converted_value)
+        return self.get_calculated_data_point(
+            dew_point_obj.f, unit_converter=TemperatureConverter
+        )
 
 
-class FeelsLikeCalculator(TemperatureUnitConverter):
+class FeelsLikeCalculator(BaseTemperatureCalculator):
     """Define a "feels like" calculator."""
 
     @Calculator.requires_keys(
@@ -227,11 +228,12 @@ class FeelsLikeCalculator(TemperatureUnitConverter):
             temp, humidity, wind_speed, self._config.input_unit_system
         )
 
-        converted_value = self.convert_value(TemperatureConverter, feels_like_obj.f)
-        return self.get_calculated_data_point(converted_value)
+        return self.get_calculated_data_point(
+            feels_like_obj.f, unit_converter=TemperatureConverter
+        )
 
 
-class FrostPointCalculator(TemperatureUnitConverter):
+class FrostPointCalculator(BaseTemperatureCalculator):
     """Define a frost point calculator."""
 
     @Calculator.requires_keys(DATA_POINT_TEMP, DATA_POINT_HUMIDITY)
@@ -247,8 +249,9 @@ class FrostPointCalculator(TemperatureUnitConverter):
         )
         frost_point_obj = get_frost_point_meteocalc_object(temp_obj, humidity)
 
-        converted_value = self.convert_value(TemperatureConverter, frost_point_obj.f)
-        return self.get_calculated_data_point(converted_value)
+        return self.get_calculated_data_point(
+            frost_point_obj.f, unit_converter=TemperatureConverter
+        )
 
 
 class FrostRiskCalculator(Calculator):
@@ -285,7 +288,7 @@ class FrostRiskCalculator(Calculator):
         return self.get_calculated_data_point(value)
 
 
-class HeatIndexCalculator(TemperatureUnitConverter):
+class HeatIndexCalculator(BaseTemperatureCalculator):
     """Define a heat index calculator."""
 
     @Calculator.requires_keys(DATA_POINT_TEMP, DATA_POINT_HUMIDITY)
@@ -300,11 +303,12 @@ class HeatIndexCalculator(TemperatureUnitConverter):
             temp, humidity, self._config.input_unit_system
         )
 
-        converted_value = self.convert_value(TemperatureConverter, heat_index_obj.f)
-        return self.get_calculated_data_point(converted_value)
+        return self.get_calculated_data_point(
+            heat_index_obj.f, unit_converter=TemperatureConverter
+        )
 
 
-class SimmerIndexCalculator(TemperatureUnitConverter):
+class SimmerIndexCalculator(BaseTemperatureCalculator):
     """Define a simmer index calculator."""
 
     @Calculator.requires_keys(DATA_POINT_TEMP, DATA_POINT_HUMIDITY)
@@ -327,8 +331,9 @@ class SimmerIndexCalculator(TemperatureUnitConverter):
             return self.get_calculated_data_point(None)
 
         assert simmer_obj
-        converted_value = self.convert_value(TemperatureConverter, simmer_obj.f)
-        return self.get_calculated_data_point(converted_value)
+        return self.get_calculated_data_point(
+            simmer_obj.f, unit_converter=TemperatureConverter
+        )
 
 
 class SimmerZoneCalculator(Calculator):
@@ -360,7 +365,7 @@ class SimmerZoneCalculator(Calculator):
         return self.get_calculated_data_point(rating.zone)
 
 
-class TemperatureCalculator(TemperatureUnitConverter):
+class TemperatureCalculator(BaseTemperatureCalculator):
     """Define a temperature calculator."""
 
     def calculate_from_value(
@@ -381,8 +386,9 @@ class TemperatureCalculator(TemperatureUnitConverter):
                 self._config.input_unit_system,
             )
 
-        converted_value = self.convert_value(TemperatureConverter, temp_obj.f)
-        return self.get_calculated_data_point(converted_value)
+        return self.get_calculated_data_point(
+            temp_obj.f, unit_converter=TemperatureConverter
+        )
 
 
 class ThermalPerceptionCalculator(Calculator):
@@ -408,7 +414,7 @@ class ThermalPerceptionCalculator(Calculator):
         return self.get_calculated_data_point(rating.perception)
 
 
-class WindChillCalculator(TemperatureUnitConverter):
+class WindChillCalculator(BaseTemperatureCalculator):
     """Define a wind chill calculator."""
 
     @Calculator.requires_keys(DATA_POINT_TEMP, DATA_POINT_WINDSPEED)
@@ -432,5 +438,6 @@ class WindChillCalculator(TemperatureUnitConverter):
             )
             return self.get_calculated_data_point(None)
 
-        converted_value = self.convert_value(TemperatureConverter, wind_chill_obj.f)
-        return self.get_calculated_data_point(converted_value)
+        return self.get_calculated_data_point(
+            wind_chill_obj.f, unit_converter=TemperatureConverter
+        )

--- a/ecowitt2mqtt/helpers/calculator/wind.py
+++ b/ecowitt2mqtt/helpers/calculator/wind.py
@@ -280,5 +280,4 @@ class WindSpeedCalculator(Calculator):
     ) -> CalculatedDataPoint:
         """Perform the calculation."""
         assert isinstance(value, float)
-        converted_value = self.convert_value(SpeedConverter, value)
-        return self.get_calculated_data_point(converted_value)
+        return self.get_calculated_data_point(value, unit_converter=SpeedConverter)


### PR DESCRIPTION
**Describe what the PR does:**

This PR removes a bunch of redundant code by allowing the passage of `UnitConverter` objects directly to a calculator's `get_calculated_data_point` method.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
