### PR TITLE
Fix invalid MQTT Discovery state with missing lightning strike distance

### DIFF
--- a/ecowitt2mqtt/helpers/calculator/__init__.py
+++ b/ecowitt2mqtt/helpers/calculator/__init__.py
@@ -21,6 +21,12 @@ _CalculateFromPayloadFuncType = Callable[
 ]
 
 
+class CalculationFailedError(EcowittError):
+    """Define an error when calcuation fails."""
+
+    pass
+
+
 class CalculationKeysMissingError(EcowittError):
     """Define an error when keys required for a calculated data point are missing."""
 

--- a/ecowitt2mqtt/helpers/calculator/time.py
+++ b/ecowitt2mqtt/helpers/calculator/time.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
-from ecowitt2mqtt.const import LOGGER, TIME_SECONDS
+from ecowitt2mqtt.const import TIME_SECONDS
 from ecowitt2mqtt.helpers.calculator import (
     CalculatedDataPoint,
+    CalculationFailedError,
     Calculator,
     SimpleCalculator,
 )
@@ -20,8 +21,7 @@ class EpochCalculator(Calculator):
     ) -> CalculatedDataPoint:
         """Perform the calculation."""
         if isinstance(value, str):
-            LOGGER.debug("Can't convert value to number: %s", value)
-            return self.get_calculated_data_point(None)
+            raise CalculationFailedError("Cannot parse value as datetime")
 
         timestamp = datetime.utcfromtimestamp(value).replace(tzinfo=timezone.utc)
         return self.get_calculated_data_point(timestamp)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1206,13 +1206,6 @@ def test_missing_distance(device_data, ecowitt, request):
             attributes={},
             data_type=DataPointType.NON_BOOLEAN,
         ),
-        "lightning_time": CalculatedDataPoint(
-            "lightning_time",
-            None,
-            unit=None,
-            attributes={},
-            data_type=DataPointType.NON_BOOLEAN,
-        ),
         "wh57batt": CalculatedDataPoint(
             "batt",
             100,
@@ -3683,13 +3676,6 @@ def test_precision(device_data, ecowitt):
                     "lightning",
                     None,
                     unit=LENGTH_MILES,
-                    attributes={},
-                    data_type=DataPointType.NON_BOOLEAN,
-                ),
-                "lightning_time": CalculatedDataPoint(
-                    "lightning_time",
-                    None,
-                    unit=None,
                     attributes={},
                     data_type=DataPointType.NON_BOOLEAN,
                 ),


### PR DESCRIPTION
**Describe what the PR does:**

Home Assistant MQTT Discovery doesn't allow `unknown` state values for entities with timestamp device class: https://github.com/home-assistant/core/blob/599d61a4da096227ce4d5ba1dc0eaabceea56f49/homeassistant/components/mqtt/sensor.py#L264-L271. Since lightning strike time can arrive as an empty value, this logs an error message.

**Does this fix a specific issue?**

Fixes https://github.com/bachya/ecowitt2mqtt/issues/348

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
