### PR TITLE
Don't swallow lightning distance calculation errors

### DIFF
--- a/ecowitt2mqtt/helpers/calculator/lightning.py
+++ b/ecowitt2mqtt/helpers/calculator/lightning.py
@@ -5,11 +5,11 @@ from ecowitt2mqtt.const import (
     CONF_OUTPUT_UNIT_DISTANCE,
     LENGTH_KILOMETERS,
     LENGTH_MILES,
-    LOGGER,
     STRIKES,
 )
 from ecowitt2mqtt.helpers.calculator import (
     CalculatedDataPoint,
+    CalculationFailedError,
     Calculator,
     SimpleCalculator,
 )
@@ -50,6 +50,6 @@ class LightningStrikeDistanceCalculator(Calculator):
     ) -> CalculatedDataPoint:
         """Perform the calculation."""
         if isinstance(value, str):
-            LOGGER.debug("Can't convert value to number: %s", value)
-            return self.get_calculated_data_point(None)
+            raise CalculationFailedError("Cannot parse value as a number")
+
         return self.get_calculated_data_point(value, unit_converter=DistanceConverter)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1199,13 +1199,6 @@ def test_missing_distance(device_data, ecowitt, request):
             attributes={},
             data_type=DataPointType.NON_BOOLEAN,
         ),
-        "lightning": CalculatedDataPoint(
-            "lightning",
-            None,
-            unit=LENGTH_MILES,
-            attributes={},
-            data_type=DataPointType.NON_BOOLEAN,
-        ),
         "wh57batt": CalculatedDataPoint(
             "batt",
             100,
@@ -3669,13 +3662,6 @@ def test_precision(device_data, ecowitt):
                     "lightning_num",
                     1,
                     unit=STRIKES,
-                    attributes={},
-                    data_type=DataPointType.NON_BOOLEAN,
-                ),
-                "lightning": CalculatedDataPoint(
-                    "lightning",
-                    None,
-                    unit=LENGTH_MILES,
                     attributes={},
                     data_type=DataPointType.NON_BOOLEAN,
                 ),


### PR DESCRIPTION
**Describe what the PR does:**

Since we introduced a new exception for calculations that fail in #350, we should also use it for lightning strike distance (instead of swallowing it).

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
