### PR TITLE
Add support for Python 3.11

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
-          - "3.11.0rc2"
+          - "3.11.0-rc.2"
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11.0rc2"
 
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ pip install ecowitt2mqtt
 * Python 3.8
 * Python 3.9
 * Python 3.10
+* Python 3.11
 
 # Disclaimer
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]


### PR DESCRIPTION
**Describe what the PR does:**

In preparation for Python 3.11's release on 10/24, this PR adds 3.11.0rc2 to CI so we can begin testing the library against it. Regular reminder that we support the three most recent versions, so when 3.11 is officially released, we will remove "official" support for 3.8.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
