### PR TITLE
Return to binding FastAPI from all addresses

### DIFF
--- a/ecowitt2mqtt/runtime.py
+++ b/ecowitt2mqtt/runtime.py
@@ -20,7 +20,7 @@ from ecowitt2mqtt.helpers.publisher.factory import get_publisher
 if TYPE_CHECKING:
     from ecowitt2mqtt.core import Ecowitt
 
-DEFAULT_HOST = "127.0.0.1"
+DEFAULT_HOST = "0.0.0.0"  # noqa: S104, # nosec: B104
 DEFAULT_MAX_RETRY_INTERVAL = 60
 
 HANDLED_SIGNALS = (


### PR DESCRIPTION
**Describe what the PR does:**

In #359, I attempted to restrict binding to the FastAPI port, but that turns out to restrict every connection except from localhost – not what we want. This PR fixes the bug.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
