### PR TITLE
Don't build redundant Docker images

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,10 +12,10 @@ name: CodeQL
       - dev
       - main
 
-  workflow_dispatch:
-
   schedule:
     - cron: "30 1 * * 0"
+
+  workflow_dispatch:
 
 jobs:
   codeql:

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -3,9 +3,6 @@ name: Publish Docker Images
 
 "on":
   push:
-    branches:
-      - dev
-      - main
     tags:
       - "*"
 

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -13,6 +13,8 @@ name: Publish Docker Images
       DOCKER_HUB_USERNAME:
         required: true
 
+  workflow_dispatch:
+
 jobs:
   publish:
     name: Publish Docker Images

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -12,6 +12,8 @@ name: Linting and Static Analysis
       - dev
       - main
 
+  workflow_dispatch:
+
 jobs:
   lint:
     name: "Linting & Static Analysis"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,8 +146,6 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   publish_docker_image:
-    name: Publish PR Docker Images
-
     needs: coverage
 
     uses: ./.github/workflows/publish-docker.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,8 @@ name: Tests and Coverage
       - dev
       - main
 
+  workflow_dispatch:
+
 jobs:
   test:
     name: Tests


### PR DESCRIPTION
**Describe what the PR does:**

We currently build redundant images when pushing to `dev` or `main`. This PR fixes things.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
