### PR TITLE
Bump Docker dependencies (OpenSSL and Poetry)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,11 +21,11 @@ RUN apk add --no-cache \
       cargo==1.60.0-r2 \
       libffi-dev==3.4.2-r1 \
       musl-dev==1.2.3-r0 \
-      openssl-dev==1.1.1q-r0 \
+      openssl-dev==1.1.1s-r0 \
       python3-dev==3.10.5-r0
 RUN printf "[global]\nextra-index-url=https://www.piwheels.org/simple\n" > /etc/pip.conf \
     && python3 -m pip install cryptography==38.0.1 \
-    && python3 -m pip install poetry==1.2.1 \
+    && python3 -m pip install poetry==1.2.2 \
     && python3 -m venv /venv
 
 COPY pyproject.toml ./


### PR DESCRIPTION
**Describe what the PR does:**

This PR bumps the version of OpenSSL and Poetry used by the Dockerfile.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
