### PR TITLE
Remove old dict merge syntax

### DIFF
--- a/ecowitt2mqtt/__main__.py
+++ b/ecowitt2mqtt/__main__.py
@@ -425,7 +425,7 @@ def main() -> None:
 
     cli_arguments = get_cli_arguments(sys.argv[1:])
     env_vars = get_env_vars()
-    params: dict[str, Any] = {**env_vars, **cli_arguments}
+    params: dict[str, Any] = env_vars | cli_arguments
 
     if CONF_DIAGNOSTICS in params:
         params[CONF_VERBOSE] = True

--- a/ecowitt2mqtt/config.py
+++ b/ecowitt2mqtt/config.py
@@ -499,12 +499,12 @@ class Configs:
             config_file_config = {}
 
         # Store the default config:
-        self._configs[CONF_DEFAULT] = Config({**config_file_config, **config})
+        self._configs[CONF_DEFAULT] = Config(config_file_config | config)
 
         # Store configs for any gateways:
         gateways_file_config = config_file_config.get(CONF_GATEWAYS, {})
         for passkey, gateway_config in gateways_file_config.items():
-            self._configs[passkey] = Config({**gateway_config, **config})
+            self._configs[passkey] = Config(gateway_config | config)
 
     def __repr__(self) -> str:
         """Define a string representation of this object.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -78,14 +78,14 @@ def test_battery_overrides_cli_options(config: dict[str, Any]) -> None:
     "raw_config",
     [
         json.dumps(
-            {
-                **TEST_CONFIG_JSON,
+            TEST_CONFIG_JSON
+            | {
                 CONF_BATTERY_OVERRIDES: {
                     "testbatt0": "boolean",
                     "testbatt1": "numeric",
                     "testbatt2": "percentage",
-                },
-            }
+                }
+            },
         )
     ],
 )
@@ -185,15 +185,15 @@ def test_config_file_empty(config_filepath: str) -> None:
     "raw_config",
     [
         json.dumps(
-            {
-                **TEST_CONFIG_JSON,
+            TEST_CONFIG_JSON
+            | {
                 CONF_GATEWAYS: {
                     "passkey123": {
                         CONF_MQTT_BROKER: "my.mqtt.local",
                         CONF_MQTT_TOPIC: "Some Topic",
                     }
-                },
-            }
+                }
+            },
         ),
     ],
 )


### PR DESCRIPTION
**Describe what the PR does:**

We had a few spots where we used a pre-Python 3.9 syntax to merge dictionaries. This PR updates those to be consistent with the new style.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
