### PR TITLE
Increase PR permissions for `publish-docker` workflow

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -15,6 +15,10 @@ name: Publish Docker Images
 
   workflow_dispatch:
 
+permissions:
+  # We increase permissions so that Dependabot-generated PRs can publish images:
+  pull-requests: write
+
 jobs:
   publish:
     name: Publish Docker Images


### PR DESCRIPTION
**Describe what the PR does:**

I'm noticing that Dependabot PRs are failing the `publish-docker` workflow (e.g., https://github.com/bachya/ecowitt2mqtt/pull/378). After reading around, I'm guessing [this](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#changing-github_token-permissions) is the issue:

> By default, GitHub Actions workflows triggered by Dependabot get a GITHUB_TOKEN with read-only permissions.

This PR increases the permissions on the `publish-docker` workflow so that Dependabot can push PR images.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
