### PR TITLE
Revert "Increase PR permissions for `publish-docker` workflow (#379)"

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -15,10 +15,6 @@ name: Publish Docker Images
 
   workflow_dispatch:
 
-permissions:
-  # We increase permissions so that Dependabot-generated PRs can publish images:
-  pull-requests: write
-
 jobs:
   publish:
     name: Publish Docker Images


### PR DESCRIPTION
**Describe what the PR does:**

PR permissioning is more complex than I thought. For now, this reverts commit b2d122d275ffa7e702caa48a4a261a5ae9c58c16.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
