### PR TITLE
Take another stab at `publish-docker` workflow permissions

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -15,6 +15,11 @@ name: Publish Docker Images
 
   workflow_dispatch:
 
+permissions:
+  # We increase packages permissions so that Dependabot-generated PRs can
+  # publish images like all other PRs:
+  packages: write
+
 jobs:
   publish:
     name: Publish Docker Images


### PR DESCRIPTION
**Describe what the PR does:**

This is another attempt to fix permissions so that Dependabot-generated PRs can push test Docker images.

**Does this fix a specific issue?**

Follow up to #379.

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
