### PR TITLE
Unpin Alpine dependencies in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,13 +16,13 @@ WORKDIR /app
 
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 RUN apk add --no-cache \
-      bash==5.1.16-r2 \
-      build-base==0.5-r3 \
-      cargo==1.60.0-r2 \
-      libffi-dev==3.4.2-r1 \
-      musl-dev==1.2.3-r1 \
-      openssl-dev==1.1.1s-r0 \
-      python3-dev==3.10.5-r0
+      bash \
+      build-base \
+      cargo \
+      libffi-dev \
+      musl-dev \
+      openssl-dev \
+      python3-dev
 RUN printf "[global]\nextra-index-url=https://www.piwheels.org/simple\n" > /etc/pip.conf \
     && python3 -m pip install cryptography==38.0.1 \
     && python3 -m pip install poetry==1.2.2 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ ENV PIP_DEFAULT_TIMEOUT=100 \
 WORKDIR /app
 
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
+# hadolint ignore=DL3018
 RUN apk add --no-cache \
       bash \
       build-base \


### PR DESCRIPTION
**Describe what the PR does:**

Although it seems nice to pin these dependencies, it ends up being rather brittle – I regularly see messages like `breaks: world[python3-dev=3.10.5-r0]`. This PR removes those pins and now relies on `apk` to manage its own dependencies.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
