### PR TITLE
Revert "Make `Configs.configs` a publicly available attribute (#395)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,9 +321,9 @@ logs when `verbose` is enabled – look for the `PASSKEY` value that the gateway
 Received data from the Ecowitt device: {'PASSKEY': 'abcde12345', ...}
 ```
 
-Then, in the configuration file, simply add a `gateways` key that contains a mapping of
-any of the existing configuration options. Options that remain at the root level of the
-file are treated as defaults.
+Then, in the configuration file, simply add a `gateways` key that contains a mapping of any
+of the existing configuration options. Options that remain at the root level of the file
+are treated as defaults.
 
 For example, this YAML configuration file:
 

--- a/ecowitt2mqtt/config.py
+++ b/ecowitt2mqtt/config.py
@@ -504,8 +504,8 @@ class Configs:
         Args:
             config: Raw configuration data.
         """
+        self._configs: dict[str, Config] = {}
         self._config_file_parser = YAML(typ="safe")
-        self.configs: dict[str, Config] = {}
 
         if config_path := config.get(CONF_CONFIG):
             config_file_config = load_config_from_file(config_path)
@@ -513,12 +513,12 @@ class Configs:
             config_file_config = {}
 
         # Store the default config:
-        self.configs[CONF_DEFAULT] = Config(config_file_config | config)
+        self._configs[CONF_DEFAULT] = Config(config_file_config | config)
 
         # Store configs for any gateways:
         gateways_file_config = config_file_config.get(CONF_GATEWAYS, {})
         for passkey, gateway_config in gateways_file_config.items():
-            self.configs[passkey] = Config(gateway_config | config)
+            self._configs[passkey] = Config(gateway_config | config)
 
     def __repr__(self) -> str:
         """Define a string representation of this object.
@@ -526,7 +526,7 @@ class Configs:
         Returns:
             A string representation.
         """
-        return f"<Configs _configs={self.configs}"
+        return f"<Configs _configs={self._configs}"
 
     @property
     def default_config(self) -> Config:
@@ -535,7 +535,7 @@ class Configs:
         Returns:
             A parsed Config object.
         """
-        return self.configs[CONF_DEFAULT]
+        return self._configs[CONF_DEFAULT]
 
     def get(self, passkey: str) -> Config:
         """Get the config for a particular passkey (returning the default if none).
@@ -546,4 +546,4 @@ class Configs:
         Returns:
             A parsed Config object.
         """
-        return self.configs.get(passkey, self.default_config)
+        return self._configs.get(passkey, self.default_config)


### PR DESCRIPTION
**Describe what the PR does:**

This reverts commit ea28c241f8b02dd0756eabd0c8eae5d59709d2a8. What I had is a less-than-ideal API.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
