### PR TITLE
Unpin dependencies in `final` stage of Docker image

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -169,6 +169,9 @@ repos:
     hooks:
       - id: hadolint
         name: 📄 Checking Dockerfile with hadolint
+        args:
+          - --ignore
+          - DL3018
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: "v3.0.0-alpha.4"

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,10 +47,11 @@ ENV PATH="/venv/bin:${PATH}"
 ENV VIRTUAL_ENV="/venv"
 
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
+# hadolint ignore=DL3018
 RUN apk add --no-cache --virtual .build-dependencies \
-      curl==7.83.1-r4 \
-      tar==1.34-r0 \
-      xz==5.2.5-r1 \
+      curl \
+      tar \
+      xz \
     && case ${TARGETPLATFORM} in \
          "linux/386")    S6_ARCH=i686  ;; \
          "linux/amd64")  S6_ARCH=x86_64  ;; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,6 @@ ENV PIP_DEFAULT_TIMEOUT=100 \
 WORKDIR /app
 
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
-# hadolint ignore=DL3018
 RUN apk add --no-cache \
       bash \
       build-base \
@@ -47,7 +46,6 @@ ENV PATH="/venv/bin:${PATH}"
 ENV VIRTUAL_ENV="/venv"
 
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
-# hadolint ignore=DL3018
 RUN apk add --no-cache --virtual .build-dependencies \
       curl \
       tar \


### PR DESCRIPTION
**Describe what the PR does:**

https://github.com/bachya/ecowitt2mqtt/pull/382 only unpinned dependencies from the `builder` stage. The pins in the `final` stage cause the build to fail, so this PR removes the pins there, too.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
