### PR TITLE
Prep for `fastapi` bump to ^0.89.1

### DIFF
--- a/ecowitt2mqtt/helpers/server.py
+++ b/ecowitt2mqtt/helpers/server.py
@@ -45,6 +45,7 @@ class APIServer(ABC):
                 self._async_handle_query,  # type: ignore[arg-type]
                 methods=[self.HTTP_REQUEST_VERB.lower()],
                 response_class=Response,
+                response_model=None,
                 status_code=status.HTTP_204_NO_CONTENT,
             )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ classifiers = [
 aiohttp = "^3.8.1"
 asyncio-mqtt = ">=0.12.1"
 colorlog = "^6.6.0"
-fastapi = ">=0.85,<0.89"
+fastapi = "^0.89.1"
 meteocalc = "^1.1.0"
 python = "^3.9.0"
 python-multipart = "^0.0.5"


### PR DESCRIPTION
**Describe what the PR does:**

Per https://github.com/tiangolo/fastapi/issues/5859#issuecomment-1377632161, `fastapi` ^0.89.1 has a new feature to determine a route's response type via method signature. This will currently fail in our codebase. This PR fixes the issue so that the bump can proceed.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
