### PR TITLE
Change HASS MQTT Discovery to publish `None` states when underlying data is missing

### DIFF
--- a/ecowitt2mqtt/helpers/publisher/hass.py
+++ b/ecowitt2mqtt/helpers/publisher/hass.py
@@ -409,8 +409,6 @@ def get_availability_payload(
     Returns:
         An availability string.
     """
-    if data_point.value is None:
-        return AVAILABILITY_OFFLINE
     return AVAILABILITY_ONLINE
 
 

--- a/ecowitt2mqtt/helpers/publisher/hass.py
+++ b/ecowitt2mqtt/helpers/publisher/hass.py
@@ -393,8 +393,6 @@ STATE_CLASS_OVERRIDES = {
     DATA_POINT_YRAIN_PIEZO: StateClass.TOTAL,
 }
 
-STATE_UNKNOWN = "unknown"
-
 
 def get_availability_payload(
     data_point: CalculatedDataPoint,
@@ -410,20 +408,6 @@ def get_availability_payload(
         An availability string.
     """
     return AVAILABILITY_ONLINE
-
-
-def get_state_payload(data_point: CalculatedDataPoint) -> CalculatedValueType:
-    """Get the state payload for a data point.
-
-    Args:
-        data_point: A parsed CalculatedDataPoint object.
-
-    Returns:
-        A state string.
-    """
-    if data_point.value is None:
-        return STATE_UNKNOWN
-    return data_point.value
 
 
 class HomeAssistantDiscoveryPublisher(
@@ -555,7 +539,7 @@ class HomeAssistantDiscoveryPublisher(
                     ),
                     (
                         discovery_payload.payload["state_topic"],
-                        get_state_payload(data_point),
+                        data_point.value,
                     ),
                 ):
                     tasks.append(

--- a/tests/helpers/publisher/test_hass_discovery.py
+++ b/tests/helpers/publisher/test_hass_discovery.py
@@ -1880,7 +1880,7 @@ async def test_publish(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/relative_strain_index/availability",
-                payload=b"offline",
+                payload=b"online",
                 retain=False,
             ),
             call(
@@ -1900,7 +1900,7 @@ async def test_publish(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/relative_strain_index_perception/availability",
-                payload=b"offline",
+                payload=b"online",
                 retain=False,
             ),
             call(
@@ -1920,7 +1920,7 @@ async def test_publish(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_1/availability",
-                payload=b"offline",
+                payload=b"online",
                 retain=False,
             ),
             call(
@@ -1940,7 +1940,7 @@ async def test_publish(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_2/availability",
-                payload=b"offline",
+                payload=b"online",
                 retain=False,
             ),
             call(
@@ -1960,7 +1960,7 @@ async def test_publish(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_3/availability",
-                payload=b"offline",
+                payload=b"online",
                 retain=False,
             ),
             call(
@@ -1980,7 +1980,7 @@ async def test_publish(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_4/availability",
-                payload=b"offline",
+                payload=b"online",
                 retain=False,
             ),
             call(
@@ -2000,7 +2000,7 @@ async def test_publish(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_5/availability",
-                payload=b"offline",
+                payload=b"online",
                 retain=False,
             ),
             call(
@@ -2020,7 +2020,7 @@ async def test_publish(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_6/availability",
-                payload=b"offline",
+                payload=b"online",
                 retain=False,
             ),
             call(
@@ -2040,7 +2040,7 @@ async def test_publish(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/simmerindex/availability",
-                payload=b"offline",
+                payload=b"online",
                 retain=False,
             ),
             call(
@@ -2060,7 +2060,7 @@ async def test_publish(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/simmerzone/availability",
-                payload=b"offline",
+                payload=b"online",
                 retain=False,
             ),
             call(
@@ -2120,7 +2120,7 @@ async def test_publish(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/windchill/availability",
-                payload=b"offline",
+                payload=b"online",
                 retain=False,
             ),
             call(
@@ -3994,7 +3994,7 @@ async def test_publish_custom_entity_id_prefix(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/relative_strain_index/availability",
-                payload=b"offline",
+                payload=b"online",
                 retain=False,
             ),
             call(
@@ -4014,7 +4014,7 @@ async def test_publish_custom_entity_id_prefix(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/relative_strain_index_perception/availability",
-                payload=b"offline",
+                payload=b"online",
                 retain=False,
             ),
             call(
@@ -4034,7 +4034,7 @@ async def test_publish_custom_entity_id_prefix(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_1/availability",
-                payload=b"offline",
+                payload=b"online",
                 retain=False,
             ),
             call(
@@ -4054,7 +4054,7 @@ async def test_publish_custom_entity_id_prefix(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_2/availability",
-                payload=b"offline",
+                payload=b"online",
                 retain=False,
             ),
             call(
@@ -4074,7 +4074,7 @@ async def test_publish_custom_entity_id_prefix(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_3/availability",
-                payload=b"offline",
+                payload=b"online",
                 retain=False,
             ),
             call(
@@ -4094,7 +4094,7 @@ async def test_publish_custom_entity_id_prefix(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_4/availability",
-                payload=b"offline",
+                payload=b"online",
                 retain=False,
             ),
             call(
@@ -4114,7 +4114,7 @@ async def test_publish_custom_entity_id_prefix(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_5/availability",
-                payload=b"offline",
+                payload=b"online",
                 retain=False,
             ),
             call(
@@ -4134,7 +4134,7 @@ async def test_publish_custom_entity_id_prefix(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_6/availability",
-                payload=b"offline",
+                payload=b"online",
                 retain=False,
             ),
             call(
@@ -4154,7 +4154,7 @@ async def test_publish_custom_entity_id_prefix(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/simmerindex/availability",
-                payload=b"offline",
+                payload=b"online",
                 retain=False,
             ),
             call(
@@ -4174,7 +4174,7 @@ async def test_publish_custom_entity_id_prefix(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/simmerzone/availability",
-                payload=b"offline",
+                payload=b"online",
                 retain=False,
             ),
             call(
@@ -4234,7 +4234,7 @@ async def test_publish_custom_entity_id_prefix(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/windchill/availability",
-                payload=b"offline",
+                payload=b"online",
                 retain=False,
             ),
             call(
@@ -6134,7 +6134,7 @@ async def test_publish_numeric_battery_strategy(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/relative_strain_index/availability",
-                payload=b"offline",
+                payload=b"online",
                 retain=False,
             ),
             call(
@@ -6154,7 +6154,7 @@ async def test_publish_numeric_battery_strategy(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/relative_strain_index_perception/availability",
-                payload=b"offline",
+                payload=b"online",
                 retain=False,
             ),
             call(
@@ -6174,7 +6174,7 @@ async def test_publish_numeric_battery_strategy(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_1/availability",
-                payload=b"offline",
+                payload=b"online",
                 retain=False,
             ),
             call(
@@ -6194,7 +6194,7 @@ async def test_publish_numeric_battery_strategy(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_2/availability",
-                payload=b"offline",
+                payload=b"online",
                 retain=False,
             ),
             call(
@@ -6214,7 +6214,7 @@ async def test_publish_numeric_battery_strategy(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_3/availability",
-                payload=b"offline",
+                payload=b"online",
                 retain=False,
             ),
             call(
@@ -6234,7 +6234,7 @@ async def test_publish_numeric_battery_strategy(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_4/availability",
-                payload=b"offline",
+                payload=b"online",
                 retain=False,
             ),
             call(
@@ -6254,7 +6254,7 @@ async def test_publish_numeric_battery_strategy(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_5/availability",
-                payload=b"offline",
+                payload=b"online",
                 retain=False,
             ),
             call(
@@ -6274,7 +6274,7 @@ async def test_publish_numeric_battery_strategy(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_6/availability",
-                payload=b"offline",
+                payload=b"online",
                 retain=False,
             ),
             call(
@@ -6294,7 +6294,7 @@ async def test_publish_numeric_battery_strategy(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/simmerindex/availability",
-                payload=b"offline",
+                payload=b"online",
                 retain=False,
             ),
             call(
@@ -6314,7 +6314,7 @@ async def test_publish_numeric_battery_strategy(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/simmerzone/availability",
-                payload=b"offline",
+                payload=b"online",
                 retain=False,
             ),
             call(
@@ -6374,7 +6374,7 @@ async def test_publish_numeric_battery_strategy(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/windchill/availability",
-                payload=b"offline",
+                payload=b"online",
                 retain=False,
             ),
             call(
@@ -8264,7 +8264,7 @@ async def test_no_entity_description(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/relative_strain_index/availability",
-                payload=b"offline",
+                payload=b"online",
                 retain=False,
             ),
             call(
@@ -8284,7 +8284,7 @@ async def test_no_entity_description(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/relative_strain_index_perception/availability",
-                payload=b"offline",
+                payload=b"online",
                 retain=False,
             ),
             call(
@@ -8304,7 +8304,7 @@ async def test_no_entity_description(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_1/availability",
-                payload=b"offline",
+                payload=b"online",
                 retain=False,
             ),
             call(
@@ -8324,7 +8324,7 @@ async def test_no_entity_description(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_2/availability",
-                payload=b"offline",
+                payload=b"online",
                 retain=False,
             ),
             call(
@@ -8344,7 +8344,7 @@ async def test_no_entity_description(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_3/availability",
-                payload=b"offline",
+                payload=b"online",
                 retain=False,
             ),
             call(
@@ -8364,7 +8364,7 @@ async def test_no_entity_description(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_4/availability",
-                payload=b"offline",
+                payload=b"online",
                 retain=False,
             ),
             call(
@@ -8384,7 +8384,7 @@ async def test_no_entity_description(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_5/availability",
-                payload=b"offline",
+                payload=b"online",
                 retain=False,
             ),
             call(
@@ -8404,7 +8404,7 @@ async def test_no_entity_description(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_6/availability",
-                payload=b"offline",
+                payload=b"online",
                 retain=False,
             ),
             call(
@@ -8424,7 +8424,7 @@ async def test_no_entity_description(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/simmerindex/availability",
-                payload=b"offline",
+                payload=b"online",
                 retain=False,
             ),
             call(
@@ -8444,7 +8444,7 @@ async def test_no_entity_description(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/simmerzone/availability",
-                payload=b"offline",
+                payload=b"online",
                 retain=False,
             ),
             call(
@@ -8504,7 +8504,7 @@ async def test_no_entity_description(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/windchill/availability",
-                payload=b"offline",
+                payload=b"online",
                 retain=False,
             ),
             call(

--- a/tests/helpers/publisher/test_hass_discovery.py
+++ b/tests/helpers/publisher/test_hass_discovery.py
@@ -1890,7 +1890,7 @@ async def test_publish(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/relative_strain_index/state",
-                payload=b"unknown",
+                payload=b"None",
                 retain=False,
             ),
             call(
@@ -1910,7 +1910,7 @@ async def test_publish(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/relative_strain_index_perception/state",
-                payload=b"unknown",
+                payload=b"None",
                 retain=False,
             ),
             call(
@@ -1930,7 +1930,7 @@ async def test_publish(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_1/state",
-                payload=b"unknown",
+                payload=b"None",
                 retain=False,
             ),
             call(
@@ -1950,7 +1950,7 @@ async def test_publish(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_2/state",
-                payload=b"unknown",
+                payload=b"None",
                 retain=False,
             ),
             call(
@@ -1970,7 +1970,7 @@ async def test_publish(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_3/state",
-                payload=b"unknown",
+                payload=b"None",
                 retain=False,
             ),
             call(
@@ -1990,7 +1990,7 @@ async def test_publish(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_4/state",
-                payload=b"unknown",
+                payload=b"None",
                 retain=False,
             ),
             call(
@@ -2010,7 +2010,7 @@ async def test_publish(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_5/state",
-                payload=b"unknown",
+                payload=b"None",
                 retain=False,
             ),
             call(
@@ -2030,7 +2030,7 @@ async def test_publish(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_6/state",
-                payload=b"unknown",
+                payload=b"None",
                 retain=False,
             ),
             call(
@@ -2050,7 +2050,7 @@ async def test_publish(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/simmerindex/state",
-                payload=b"unknown",
+                payload=b"None",
                 retain=False,
             ),
             call(
@@ -2070,7 +2070,7 @@ async def test_publish(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/simmerzone/state",
-                payload=b"unknown",
+                payload=b"None",
                 retain=False,
             ),
             call(
@@ -2130,7 +2130,7 @@ async def test_publish(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/windchill/state",
-                payload=b"unknown",
+                payload=b"None",
                 retain=False,
             ),
         ]
@@ -4004,7 +4004,7 @@ async def test_publish_custom_entity_id_prefix(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/relative_strain_index/state",
-                payload=b"unknown",
+                payload=b"None",
                 retain=False,
             ),
             call(
@@ -4024,7 +4024,7 @@ async def test_publish_custom_entity_id_prefix(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/relative_strain_index_perception/state",
-                payload=b"unknown",
+                payload=b"None",
                 retain=False,
             ),
             call(
@@ -4044,7 +4044,7 @@ async def test_publish_custom_entity_id_prefix(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_1/state",
-                payload=b"unknown",
+                payload=b"None",
                 retain=False,
             ),
             call(
@@ -4064,7 +4064,7 @@ async def test_publish_custom_entity_id_prefix(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_2/state",
-                payload=b"unknown",
+                payload=b"None",
                 retain=False,
             ),
             call(
@@ -4084,7 +4084,7 @@ async def test_publish_custom_entity_id_prefix(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_3/state",
-                payload=b"unknown",
+                payload=b"None",
                 retain=False,
             ),
             call(
@@ -4104,7 +4104,7 @@ async def test_publish_custom_entity_id_prefix(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_4/state",
-                payload=b"unknown",
+                payload=b"None",
                 retain=False,
             ),
             call(
@@ -4124,7 +4124,7 @@ async def test_publish_custom_entity_id_prefix(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_5/state",
-                payload=b"unknown",
+                payload=b"None",
                 retain=False,
             ),
             call(
@@ -4144,7 +4144,7 @@ async def test_publish_custom_entity_id_prefix(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_6/state",
-                payload=b"unknown",
+                payload=b"None",
                 retain=False,
             ),
             call(
@@ -4164,7 +4164,7 @@ async def test_publish_custom_entity_id_prefix(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/simmerindex/state",
-                payload=b"unknown",
+                payload=b"None",
                 retain=False,
             ),
             call(
@@ -4184,7 +4184,7 @@ async def test_publish_custom_entity_id_prefix(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/simmerzone/state",
-                payload=b"unknown",
+                payload=b"None",
                 retain=False,
             ),
             call(
@@ -4244,7 +4244,7 @@ async def test_publish_custom_entity_id_prefix(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/windchill/state",
-                payload=b"unknown",
+                payload=b"None",
                 retain=False,
             ),
         ]
@@ -6144,7 +6144,7 @@ async def test_publish_numeric_battery_strategy(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/relative_strain_index/state",
-                payload=b"unknown",
+                payload=b"None",
                 retain=False,
             ),
             call(
@@ -6164,7 +6164,7 @@ async def test_publish_numeric_battery_strategy(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/relative_strain_index_perception/state",
-                payload=b"unknown",
+                payload=b"None",
                 retain=False,
             ),
             call(
@@ -6184,7 +6184,7 @@ async def test_publish_numeric_battery_strategy(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_1/state",
-                payload=b"unknown",
+                payload=b"None",
                 retain=False,
             ),
             call(
@@ -6204,7 +6204,7 @@ async def test_publish_numeric_battery_strategy(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_2/state",
-                payload=b"unknown",
+                payload=b"None",
                 retain=False,
             ),
             call(
@@ -6224,7 +6224,7 @@ async def test_publish_numeric_battery_strategy(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_3/state",
-                payload=b"unknown",
+                payload=b"None",
                 retain=False,
             ),
             call(
@@ -6244,7 +6244,7 @@ async def test_publish_numeric_battery_strategy(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_4/state",
-                payload=b"unknown",
+                payload=b"None",
                 retain=False,
             ),
             call(
@@ -6264,7 +6264,7 @@ async def test_publish_numeric_battery_strategy(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_5/state",
-                payload=b"unknown",
+                payload=b"None",
                 retain=False,
             ),
             call(
@@ -6284,7 +6284,7 @@ async def test_publish_numeric_battery_strategy(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_6/state",
-                payload=b"unknown",
+                payload=b"None",
                 retain=False,
             ),
             call(
@@ -6304,7 +6304,7 @@ async def test_publish_numeric_battery_strategy(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/simmerindex/state",
-                payload=b"unknown",
+                payload=b"None",
                 retain=False,
             ),
             call(
@@ -6324,7 +6324,7 @@ async def test_publish_numeric_battery_strategy(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/simmerzone/state",
-                payload=b"unknown",
+                payload=b"None",
                 retain=False,
             ),
             call(
@@ -6384,7 +6384,7 @@ async def test_publish_numeric_battery_strategy(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/windchill/state",
-                payload=b"unknown",
+                payload=b"None",
                 retain=False,
             ),
         ]
@@ -8274,7 +8274,7 @@ async def test_no_entity_description(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/relative_strain_index/state",
-                payload=b"unknown",
+                payload=b"None",
                 retain=False,
             ),
             call(
@@ -8294,7 +8294,7 @@ async def test_no_entity_description(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/relative_strain_index_perception/state",
-                payload=b"unknown",
+                payload=b"None",
                 retain=False,
             ),
             call(
@@ -8314,7 +8314,7 @@ async def test_no_entity_description(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_1/state",
-                payload=b"unknown",
+                payload=b"None",
                 retain=False,
             ),
             call(
@@ -8334,7 +8334,7 @@ async def test_no_entity_description(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_2/state",
-                payload=b"unknown",
+                payload=b"None",
                 retain=False,
             ),
             call(
@@ -8354,7 +8354,7 @@ async def test_no_entity_description(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_3/state",
-                payload=b"unknown",
+                payload=b"None",
                 retain=False,
             ),
             call(
@@ -8374,7 +8374,7 @@ async def test_no_entity_description(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_4/state",
-                payload=b"unknown",
+                payload=b"None",
                 retain=False,
             ),
             call(
@@ -8394,7 +8394,7 @@ async def test_no_entity_description(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_5/state",
-                payload=b"unknown",
+                payload=b"None",
                 retain=False,
             ),
             call(
@@ -8414,7 +8414,7 @@ async def test_no_entity_description(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/safe_exposure_time_skin_type_6/state",
-                payload=b"unknown",
+                payload=b"None",
                 retain=False,
             ),
             call(
@@ -8434,7 +8434,7 @@ async def test_no_entity_description(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/simmerindex/state",
-                payload=b"unknown",
+                payload=b"None",
                 retain=False,
             ),
             call(
@@ -8454,7 +8454,7 @@ async def test_no_entity_description(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/simmerzone/state",
-                payload=b"unknown",
+                payload=b"None",
                 retain=False,
             ),
             call(
@@ -8514,7 +8514,7 @@ async def test_no_entity_description(
             ),
             call(
                 "homeassistant/sensor/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/windchill/state",
-                payload=b"unknown",
+                payload=b"None",
                 retain=False,
             ),
         ]


### PR DESCRIPTION
**Describe what the PR does:**

Home Assistant fixed https://github.com/bachya/ecowitt2mqtt/issues/437 in the 2023.2 betas, in which case #444 can be reverted and adjusted to publish `None` when underlying data is missing.

**Does this fix a specific issue?**

Fixes #437

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
