### PR TITLE
Fix broken `cryptography` in Docker build

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -69,9 +69,7 @@ jobs:
           context: .
           file: ./Dockerfile
           platforms: >-
-            linux/386,
             linux/amd64,
-            linux/arm/v6,
             linux/arm/v7,
             linux/arm64
           push: true

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -69,7 +69,6 @@ jobs:
           context: .
           file: ./Dockerfile
           platforms: >-
-            linux/386,
             linux/amd64,
             linux/arm/v6,
             linux/arm/v7,

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -69,7 +69,9 @@ jobs:
           context: .
           file: ./Dockerfile
           platforms: >-
+            linux/386,
             linux/amd64,
+            linux/arm/v6,
             linux/arm/v7,
             linux/arm64
           push: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -164,9 +164,9 @@ repos:
         name: 📄 Checking Dockerfile with hadolint
         args:
           - --ignore
-          - DL3013
+          - DL3008
           - --ignore
-          - DL3018
+          - DL3013
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: "v3.0.0-alpha.4"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -164,6 +164,8 @@ repos:
         name: 📄 Checking Dockerfile with hadolint
         args:
           - --ignore
+          - DL3013
+          - --ignore
           - DL3018
 
   - repo: https://github.com/pre-commit/mirrors-prettier

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,8 @@ RUN apk add --no-cache \
       openssl-dev \
       python3-dev
 RUN printf "[global]\nextra-index-url=https://www.piwheels.org/simple\n" > /etc/pip.conf \
-    && python3 -m pip install cryptography==38.0.1 \
-    && python3 -m pip install poetry==1.2.2 \
+    && python3 -m pip install cryptography==40.0.1 \
+    && python3 -m pip install poetry==1.4.2 \
     && python3 -m venv /venv
 
 COPY pyproject.toml ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Add rust:
+ENV PATH="${HOME}/.cargo/bin:${PATH}"
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y \
     && rustup toolchain install nightly
-ENV PATH="${HOME}/.cargo/bin:${PATH}"
 
 # Add poetry and build dependencies:
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,12 +24,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Add rust:
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y \
-    && echo "source $HOME/.cargo/env" >> "$HOME/.bashrc"
+ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Add poetry and build dependencies:
 COPY . .
 RUN printf "[global]\nextra-index-url=https://www.piwheels.org/simple\n" > /etc/pip.conf \
     && python3 -m pip install --upgrade pip \
+    && python3 -m pip install cryptography==40.0.1 \
     && python3 -m pip install poetry==1.4.2 \
     && python3 -m venv /venv
 RUN poetry lock \

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Add rust:
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
-ENV PATH="/root/.cargo/bin:${PATH}"
+ENV PATH="${HOME}/.cargo/bin:${PATH}"
 
 # Add poetry and build dependencies:
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Add rust:
-RUN curl https://sh.rustup.rs -sSf | bash -s -- -y \
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Add poetry and build dependencies:

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN apk add --no-cache \
       libffi-dev \
       musl-dev \
       openssl-dev \
+      py3-cryptography \
       python3-dev
 RUN printf "[global]\nextra-index-url=https://www.piwheels.org/simple\n" > /etc/pip.conf \
     && python3 -m pip install poetry==1.4.2 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Add rust:
-ENV PATH="${HOME}/.cargo/bin:${PATH}"
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y \
-    && rustup toolchain install nightly
+    && /root/.cargo/bin/rustup toolchain install nightly
 
 # Add poetry and build dependencies:
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       tar \
       xz-utils \
     && case ${TARGETPLATFORM} in \
-         "linux/386")    S6_ARCH=i686  ;; \
          "linux/amd64")  S6_ARCH=x86_64  ;; \
          "linux/arm/v6") S6_ARCH=arm  ;; \
          "linux/arm/v7") S6_ARCH=arm  ;; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Add rust:
-RUN curl https://sh.rustup.rs -sSf | bash -s -- -y \
-    && /root/.cargo/bin/rustup toolchain install nightly
+ENV PATH="/root/.cargo/bin:${PATH}"
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y && rustup toolchain install nightly
 
 # Add poetry and build dependencies:
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Define the base image:
-FROM python:3.11.0-alpine as base
+FROM python:3.11-alpine as base
 ENV PYTHONFAULTHANDLER=1 \
     PYTHONHASHSEED=random \
     PYTHONUNBUFFERED=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,6 @@ RUN apk add --no-cache \
       openssl-dev \
       python3-dev
 RUN printf "[global]\nextra-index-url=https://www.piwheels.org/simple\n" > /etc/pip.conf \
-    && python3 -m pip install cryptography==40.0.1 \
     && python3 -m pip install poetry==1.4.2 \
     && python3 -m venv /venv
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,9 @@ RUN apk add --no-cache \
       libffi-dev \
       musl-dev \
       openssl-dev \
-      py3-cryptography \
       python3-dev
 RUN printf "[global]\nextra-index-url=https://www.piwheels.org/simple\n" > /etc/pip.conf \
+    && python3 -m pip install --upgrade pip \
     && python3 -m pip install poetry==1.4.2 \
     && python3 -m venv /venv
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Add rust:
-RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y \
+    && rustup toolchain install nightly
 ENV PATH="${HOME}/.cargo/bin:${PATH}"
 
 # Add poetry and build dependencies:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -5,8 +5,6 @@ services:
   ecowitt2mqtt:
     build:
       context: .
-      args:
-        TARGETPLATFORM: linux/amd64
     container_name: ecowitt2mqtt
     environment:
       ECOWITT2MQTT_MQTT_BROKER: vernemq


### PR DESCRIPTION
**Describe what the PR does:**

`cryptography` recently started breaking during the build of armv6 and armv7 Docker images. To fix this, we revert the Dockerfile to use Python 3.9 as a base so that we can fetch pre-built wheels. We also stop producing the `i386` image, as it does not have a wheel and would require manual compilation via the Rust toolchain.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
