### PR TITLE
Allow the specification of multiple publishers

### DIFF
--- a/ecowitt2mqtt/config.py
+++ b/ecowitt2mqtt/config.py
@@ -81,7 +81,6 @@ HASS_DISCOVERY_SCHEMA = vol.Schema(
 MQTT_TOPIC_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_MQTT_TOPIC): str,
-        vol.Optional(CONF_HASS_DISCOVERY, default=False): vol.All(cv.boolean, False),
     },
     extra=vol.ALLOW_EXTRA,
 )

--- a/ecowitt2mqtt/helpers/publisher/factory.py
+++ b/ecowitt2mqtt/helpers/publisher/factory.py
@@ -9,16 +9,19 @@ from ecowitt2mqtt.helpers.publisher.hass import HomeAssistantDiscoveryPublisher
 from ecowitt2mqtt.helpers.publisher.topic import TopicPublisher
 
 
-def get_publisher(config: Config, client: Client) -> MqttPublisher:
-    """Get an MQTT publisher.
+def get_publishers(config: Config, client: Client) -> list[MqttPublisher]:
+    """Get configured MQTT publishers.
 
     Args:
         config: A Config object.
         client: An MQTT Client object.
 
     Returns:
-        An MqttPublisher object.
+        A list of MqttPublisher objects.
     """
+    publishers: list[MqttPublisher] = []
     if config.hass_discovery:
-        return HomeAssistantDiscoveryPublisher(config, client)
-    return TopicPublisher(config, client)
+        publishers.append(HomeAssistantDiscoveryPublisher(config, client))
+    if config.mqtt_topic:
+        publishers.append(TopicPublisher(config, client))
+    return publishers

--- a/tests/helpers/publisher/test_hass_discovery.py
+++ b/tests/helpers/publisher/test_hass_discovery.py
@@ -16,7 +16,7 @@ from ecowitt2mqtt.const import (
 )
 from ecowitt2mqtt.core import Ecowitt
 from ecowitt2mqtt.helpers.calculator.battery import BatteryStrategy
-from ecowitt2mqtt.helpers.publisher.factory import get_publisher
+from ecowitt2mqtt.helpers.publisher.factory import get_publishers
 from ecowitt2mqtt.helpers.publisher.hass import HomeAssistantDiscoveryPublisher
 from tests.common import TEST_CONFIG_JSON, TEST_HASS_ENTITY_ID_PREFIX
 
@@ -29,8 +29,10 @@ def test_get_publisher(ecowitt: Ecowitt, mock_asyncio_mqtt_client: MagicMock) ->
         ecowitt: A parsed Ecowitt object.
         mock_asyncio_mqtt_client: A mock asyncio-mqtt Client object.
     """
-    publisher = get_publisher(ecowitt.configs.default_config, mock_asyncio_mqtt_client)
-    assert isinstance(publisher, HomeAssistantDiscoveryPublisher)
+    publishers = get_publishers(
+        ecowitt.configs.default_config, mock_asyncio_mqtt_client
+    )
+    assert isinstance(publishers[0], HomeAssistantDiscoveryPublisher)
 
 
 @pytest.mark.asyncio
@@ -50,8 +52,10 @@ async def test_publish(
         ecowitt: A parsed Ecowitt object.
         mock_asyncio_mqtt_client: A mock asyncio-mqtt Client object.
     """
-    publisher = get_publisher(ecowitt.configs.default_config, mock_asyncio_mqtt_client)
-    await publisher.async_publish(device_data)
+    publishers = get_publishers(
+        ecowitt.configs.default_config, mock_asyncio_mqtt_client
+    )
+    await publishers[0].async_publish(device_data)
     mock_asyncio_mqtt_client.publish.assert_has_awaits(
         [
             call(
@@ -2284,8 +2288,10 @@ async def test_publish_custom_entity_id_prefix(
         ecowitt: A parsed Ecowitt object.
         mock_asyncio_mqtt_client: A mock asyncio-mqtt Client object.
     """
-    publisher = get_publisher(ecowitt.configs.default_config, mock_asyncio_mqtt_client)
-    await publisher.async_publish(device_data)
+    publishers = get_publishers(
+        ecowitt.configs.default_config, mock_asyncio_mqtt_client
+    )
+    await publishers[0].async_publish(device_data)
     mock_asyncio_mqtt_client.publish.assert_has_awaits(
         [
             call(
@@ -4515,9 +4521,11 @@ async def test_publish_error_mqtt(
         ecowitt: A parsed Ecowitt object.
         mock_asyncio_mqtt_client: A mock asyncio-mqtt Client object.
     """
-    publisher = get_publisher(ecowitt.configs.default_config, mock_asyncio_mqtt_client)
+    publishers = get_publishers(
+        ecowitt.configs.default_config, mock_asyncio_mqtt_client
+    )
     with pytest.raises(MqttError):
-        await publisher.async_publish(device_data)
+        await publishers[0].async_publish(device_data)
 
 
 @pytest.mark.asyncio
@@ -4544,8 +4552,10 @@ async def test_publish_numeric_battery_strategy(
         ecowitt: A parsed Ecowitt object.
         mock_asyncio_mqtt_client: A mock asyncio-mqtt Client object.
     """
-    publisher = get_publisher(ecowitt.configs.default_config, mock_asyncio_mqtt_client)
-    await publisher.async_publish(device_data)
+    publishers = get_publishers(
+        ecowitt.configs.default_config, mock_asyncio_mqtt_client
+    )
+    await publishers[0].async_publish(device_data)
     mock_asyncio_mqtt_client.publish.assert_has_awaits(
         [
             call(
@@ -6774,8 +6784,10 @@ async def test_no_entity_description(
     caplog.set_level(logging.DEBUG)
     device_data["random"] = "value"
 
-    publisher = get_publisher(ecowitt.configs.default_config, mock_asyncio_mqtt_client)
-    await publisher.async_publish(device_data)
+    publishers = get_publishers(
+        ecowitt.configs.default_config, mock_asyncio_mqtt_client
+    )
+    await publishers[0].async_publish(device_data)
     mock_asyncio_mqtt_client.publish.assert_has_awaits(
         [
             call(

--- a/tests/helpers/publisher/test_topic_publisher.py
+++ b/tests/helpers/publisher/test_topic_publisher.py
@@ -8,7 +8,7 @@ import pytest
 from ecowitt2mqtt.const import CONF_MQTT_RETAIN, CONF_RAW_DATA
 from ecowitt2mqtt.core import Ecowitt
 from ecowitt2mqtt.helpers.publisher import generate_mqtt_payload
-from ecowitt2mqtt.helpers.publisher.factory import get_publisher
+from ecowitt2mqtt.helpers.publisher.factory import get_publishers
 from ecowitt2mqtt.helpers.publisher.topic import TopicPublisher
 from tests.common import TEST_CONFIG_JSON, TEST_MQTT_TOPIC
 
@@ -20,8 +20,10 @@ def test_get_publisher(ecowitt: Ecowitt, mock_asyncio_mqtt_client: MagicMock) ->
         ecowitt: A parsed Ecowitt object.
         mock_asyncio_mqtt_client: A mock asyncio-mqtt Client object.
     """
-    publisher = get_publisher(ecowitt.configs.default_config, mock_asyncio_mqtt_client)
-    assert isinstance(publisher, TopicPublisher)
+    publishers = get_publishers(
+        ecowitt.configs.default_config, mock_asyncio_mqtt_client
+    )
+    assert isinstance(publishers[0], TopicPublisher)
 
 
 @pytest.mark.asyncio
@@ -37,8 +39,10 @@ async def test_publish_processed(
         ecowitt: A parsed Ecowitt object.
         mock_asyncio_mqtt_client: A mock asyncio-mqtt Client object.
     """
-    publisher = get_publisher(ecowitt.configs.default_config, mock_asyncio_mqtt_client)
-    await publisher.async_publish(device_data)
+    publishers = get_publishers(
+        ecowitt.configs.default_config, mock_asyncio_mqtt_client
+    )
+    await publishers[0].async_publish(device_data)
     mock_asyncio_mqtt_client.publish.assert_awaited_with(
         TEST_MQTT_TOPIC,
         payload=b'{"runtime": 319206.0, "tempin": 79.52, "humidityin": 31.0, "baromrel": 24.74, "baromabs": 24.74, "temp": 93.2, "humidity": 64.0, "winddir": 139.0, "windspeed": 20.89, "windgust": 1.12, "maxdailygust": 8.05, "solarradiation": 264.61, "uv": 2.0, "rainrate": 0.0, "eventrain": 0.0, "hourlyrain": 0.0, "dailyrain": 0.0, "weeklyrain": 0.0, "monthlyrain": 2.177, "yearlyrain": 4.441, "lightning_num": 13.0, "lightning": 0.6213711922373341, "lightning_time": "2022-04-20T17:17:17+00:00", "wh65batt": "OFF", "beaufortscale": 5, "dewpoint": 79.19328776816637, "feelslike": 111.0553021896001, "frostpoint": 70.28882284994654, "frostrisk": "No risk", "heatindex": 111.0553021896001, "humidex": 48, "humidex_perception": "Dangerous", "humidityabs": 0.001501643470436062, "humidityabsin": 0.001501643470436062, "relative_strain_index": 0.54, "relative_strain_index_perception": "Extreme discomfort", "safe_exposure_time_skin_type_1": 83.3, "safe_exposure_time_skin_type_2": 100.0, "safe_exposure_time_skin_type_3": 133.3, "safe_exposure_time_skin_type_4": 166.7, "safe_exposure_time_skin_type_5": 266.7, "safe_exposure_time_skin_type_6": 433.3, "simmerindex": 113.90619200000002, "simmerzone": "Danger of heatstroke", "solarradiation_perceived": 90.49958322993245, "thermalperception": "Severely high", "windchill": null}',  # noqa: E501
@@ -60,8 +64,10 @@ async def test_publish_raw(
         ecowitt: A parsed Ecowitt object.
         mock_asyncio_mqtt_client: A mock asyncio-mqtt Client object.
     """
-    publisher = get_publisher(ecowitt.configs.default_config, mock_asyncio_mqtt_client)
-    await publisher.async_publish(device_data)
+    publishers = get_publishers(
+        ecowitt.configs.default_config, mock_asyncio_mqtt_client
+    )
+    await publishers[0].async_publish(device_data)
     mock_asyncio_mqtt_client.publish.assert_awaited_with(
         TEST_MQTT_TOPIC, payload=generate_mqtt_payload(device_data), retain=False
     )
@@ -83,8 +89,10 @@ async def test_publish_retain(
         ecowitt: A parsed Ecowitt object.
         mock_asyncio_mqtt_client: A mock asyncio-mqtt Client object.
     """
-    publisher = get_publisher(ecowitt.configs.default_config, mock_asyncio_mqtt_client)
-    await publisher.async_publish(device_data)
+    publishers = get_publishers(
+        ecowitt.configs.default_config, mock_asyncio_mqtt_client
+    )
+    await publishers[0].async_publish(device_data)
     mock_asyncio_mqtt_client.publish.assert_awaited_with(
         TEST_MQTT_TOPIC, payload=generate_mqtt_payload(device_data), retain=True
     )

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -2,6 +2,7 @@
 # pylint: disable=line-too-long,too-many-arguments,unused-argument
 from __future__ import annotations
 
+import asyncio
 import json
 import urllib.parse
 from collections.abc import AsyncGenerator
@@ -46,6 +47,8 @@ async def test_publish_failure(
         await session.request(
             "post", f"http://127.0.0.1:{TEST_PORT}{TEST_ENDPOINT}", data=device_data
         )
+
+    await asyncio.sleep(0.1)
     assert any(m for m in caplog.messages if "There was an MQTT error" in m)
 
 
@@ -82,6 +85,7 @@ async def test_publish_ambient_weather_success(
             "get", f"http://127.0.0.1:{TEST_PORT}{TEST_ENDPOINT}{payload_string}"
         )
 
+    await asyncio.sleep(0.1)
     assert resp.status == 204
     mock_asyncio_mqtt_client.publish.assert_awaited_with(
         TEST_MQTT_TOPIC,
@@ -127,6 +131,7 @@ async def test_publish_ecowitt_success(
             data=device_data,
         )
 
+    await asyncio.sleep(0.1)
     assert resp.status == 204
     mock_asyncio_mqtt_client.publish.assert_awaited_with(
         TEST_MQTT_TOPIC,
@@ -163,4 +168,6 @@ async def test_unknown_exception_shutdown(
         await session.request(
             "post", f"http://127.0.0.1:{TEST_PORT}{TEST_ENDPOINT}", data=device_data
         )
+
+    await asyncio.sleep(0.1)
     assert any(m for m in caplog.messages if "Something horrible happened" in m)


### PR DESCRIPTION
**Describe what the PR does:**

SSIA. For instance, this allows users to specify both `--mqtt-topic` and `--hass-discovery` and have messages published to *both* standards.

**Does this fix a specific issue?**

Fixes https://github.com/bachya/ecowitt2mqtt/issues/543

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
