### PR TITLE
Reduce likelihood of log warnings about `pending publish calls`

### DIFF
--- a/ecowitt2mqtt/runtime.py
+++ b/ecowitt2mqtt/runtime.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import asyncio
-import signal
 import traceback
 from contextlib import suppress
 from ssl import SSLContext
@@ -22,17 +21,13 @@ if TYPE_CHECKING:
 
 DEFAULT_HOST = "0.0.0.0"  # noqa: S104, # nosec: B104
 DEFAULT_MAX_RETRY_INTERVAL = 60
-
-HANDLED_SIGNALS = (
-    signal.SIGINT,  # Unix signal 2. Sent by Ctrl+C.
-    signal.SIGTERM,  # Unix signal 15. Sent by `kill <pid>`.
-)
+DEFAULT_PENDING_CALLS_THRESHOLD = 500
 
 UVICORN_LOG_LEVEL_DEBUG = "debug"
 UVICORN_LOG_LEVEL_ERROR = "error"
 
 
-class Runtime:  # pylint: disable=too-many-instance-attributes
+class Runtime:
     """Define the runtime manager."""
 
     def __init__(self, ecowitt: Ecowitt) -> None:
@@ -106,6 +101,9 @@ class Runtime:  # pylint: disable=too-many-instance-attributes
                             tls_context=SSLContext() if config.mqtt_tls else None,
                             username=config.mqtt_username,
                         ) as client:
+                            client.pending_calls_threshold = (
+                                DEFAULT_PENDING_CALLS_THRESHOLD
+                            )
                             publishers = get_publishers(config, client)
                             while True:
                                 await payload_event.wait()


### PR DESCRIPTION
**Describe what the PR does:**

`aiomqtt` will automatically log warnings if there are more than 10 pending MQTT publish calls. We often have _way_ more than that, and I've yet to see it be an issue (given that we have a delay between receiving data from a gateway and publishing it)—so, this PR adjusts things to only log the warning if there appear to an abnormal number of pending calls.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
