### PR TITLE
Update README.md, Docker with ECOWITT2MQTT_MQTT_TOPIC

### DIFF
--- a/README.md
+++ b/README.md
@@ -749,6 +749,7 @@ docker run -it \
     -e ECOWITT2MQTT_MQTT_BROKER=192.168.1.101 \
     -e ECOWITT2MQTT_MQTT_USERNAME=user \
     -e ECOWITT2MQTT_MQTT_PASSWORD=password \
+    -e ECOWITT2MQTT_MQTT_TOPIC=topic \
     -p 8080:8080 \
     bachya/ecowitt2mqtt:latest
 ```


### PR DESCRIPTION
The docker run command needs the "ECOWITT2MQTT_MQTT_TOPIC" parameter set. Otherwise it does not start.

**Describe what the PR does:**
It helps to run ecowitt2mqtt with docker. No error massage.

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality. -> not needed
- [ ] Run tests and ensure everything passes (with 100% test coverage). -> not needed
- [x] Update `README.md` with any new documentation.
