### PR TITLE
Fix config error when ports are passed as strings

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -471,6 +471,27 @@ def test_precision() -> None:
 
 
 @pytest.mark.parametrize(
+    "config,is_valid",
+    (
+        [TEST_CONFIG_JSON | {CONF_PORT: 1883}, True],
+        [TEST_CONFIG_JSON | {CONF_PORT: 9000}, True],
+        [TEST_CONFIG_JSON | {CONF_PORT: "1883"}, True],
+        [TEST_CONFIG_JSON | {CONF_PORT: "Not a port"}, False],
+    ),
+)
+def test_port(config: dict[str, Any], is_valid: bool) -> None:
+    """Test validating a port.
+
+    Args:
+        config: A configuration dictionary.
+        is_valid: Whether the configuration is valid.
+    """
+    if not is_valid:
+        with pytest.raises(ConfigError):
+            _ = Configs(config)
+
+
+@pytest.mark.parametrize(
     "config,verbose_value",
     [
         (TEST_CONFIG_JSON | {CONF_VERBOSE: "yes"}, True),


### PR DESCRIPTION
**Describe what the PR does:**

SSIA. I saw this in the Home Assistant add-on:

```
2 validation errors for Config
mqtt_port
  Input should be a valid integer [type=int_type, input_value='1883', input_type=str]
    For further information visit https://errors.pydantic.dev/2.5/v/int_type
port
  Input should be a valid integer [type=int_type, input_value='8080', input_type=str]
    For further information visit https://errors.pydantic.dev/2.5/v/int_type
```

**Does this fix a specific issue?**

N/A

**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
