### PR TITLE
Add Ecowitt HP2561 to device mapping

### DIFF
--- a/ecowitt2mqtt/helpers/device.py
+++ b/ecowitt2mqtt/helpers/device.py
@@ -17,6 +17,7 @@ MODEL_BRAND_MAP = {
     "HP2550": "Ecowitt",
     "HP2551": "Ecowitt",
     "HP2553": "Ecowitt",
+    "HP2561": "Ecowitt",
     "HP2564": "Ecowitt",
     "PT-HP2550": "Fine Offset",
     "WH2650": "Fine Offset",


### PR DESCRIPTION
**Describe what the PR does:**

Adds a new device (HP2561) to the mapping

**Does this fix a specific issue?**

Fixes https://github.com/bachya/ecowitt2mqtt/issues/883

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
