### PR TITLE
fix: fix issue with runtime cancellation prior to MQTT publish

### DIFF
--- a/ecowitt2mqtt/runtime.py
+++ b/ecowitt2mqtt/runtime.py
@@ -180,7 +180,10 @@ class Runtime:
         """Start the runtime."""
         LOGGER.debug("Starting runtime")
         self._rest_api_server_task = asyncio.create_task(self._uvicorn.serve())
-        await self._rest_api_server_task
+        try:
+            await self._rest_api_server_task
+        except asyncio.CancelledError:
+            LOGGER.debug("Runtime task successfully cancelled")
 
     def stop(self) -> None:
         """Stop the REST API server."""


### PR DESCRIPTION
**Describe what the PR does:**

Currently, canceling the runtime before an MQTT publish occurs throws an unhandled exception.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
