### PR TITLE
Add support for socket activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -694,6 +694,22 @@ To enable the service:
 $ systemctl enable ecowitt2mqtt
 ```
 
+Alternatively, socket activation can be used to let systemd open the port for the application.  This
+is especially useful when paired with Podman allowing a usermode process to listen for connections
+without a slirp4ns proxy.  Socket activation can be enabled by creating a systemd socket file
+with the same base-name as the service file.  For example:
+
+```
+[Unit]
+Description=ecowitt2mqtt service
+
+[Socket]
+ListenStream=[::]:8080
+
+[Install]
+WantedBy=sockets.target
+```
+
 ## Docker
 
 The library is available via a Docker image from both [Docker Hub][docker-hub] and


### PR DESCRIPTION
**Describe what the PR does:**
Allows ecowitt2mqtt to detect the presence of Systemd socket-activation, and to automatically listen on the provided socket.  I use this with a rootless Podman container so that I don't need to use slirp4ns to proxy netwotk connections.
In theory, if it were paired with mosquitto running over unix-domain-sockets, it would allow the podman container to run
without any networking at all, thus improving security, but my MQTT server is on another box, and that is not a direction I'm pursuing.

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
  - I'm not sure how a test would be written to test socket-activation here.
- [X] Run tests and ensure everything passes (with 100% test coverage).
- [X] Update `README.md` with any new documentation.
