### PR TITLE
fix!: remove `armv6` and `armv7` as supported Docker targets

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -70,7 +70,6 @@ jobs:
           file: ./Dockerfile
           platforms: >-
             linux/amd64,
-            linux/arm/v7,
             linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -70,7 +70,6 @@ jobs:
           file: ./Dockerfile
           platforms: >-
             linux/amd64,
-            linux/arm/v6,
             linux/arm/v7,
             linux/arm64
           push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,16 +3,16 @@
 #
 # This stage is responsible for building the ecowitt2mqtt package and its dependencies.
 ########################################################################################
-FROM python:3.11-alpine as builder
+FROM python:3.11-alpine AS builder
 ARG TARGETPLATFORM
 
 # Set up the build environment:
-ENV CRYPTOGRAPHY_VERSION=41.0.5 \
+ENV CRYPTOGRAPHY_VERSION=42.0.8 \
     PIP_DEFAULT_TIMEOUT=100 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PIP_NO_CACHE_DIR=1 \
     PIP_PREFER_BINARY=1 \
-    POETRY_VERSION=1.7.1 \
+    POETRY_VERSION=2.1.2 \
     PYTHONFAULTHANDLER=1 \
     PYTHONHASHSEED=random \
     PYTHONUNBUFFERED=1
@@ -44,7 +44,7 @@ RUN poetry export --without-hashes -f requirements.txt --only main \
 #
 # This stage is responsible for building the final image.
 ########################################################################################
-FROM python:3.11-alpine as final
+FROM python:3.11-alpine AS final
 ARG TARGETPLATFORM
 
 # Copy the virtual environment from the builder image:

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN apk add --no-cache \
 # Add poetry and build dependencies:
 COPY . .
 RUN pip install --upgrade pip \
-    && pip install poetry==${POETRY_VERSION} \
+    && pip install poetry==${POETRY_VERSION} "poetry-plugin-export"\
     && python3 -m venv /venv
 RUN poetry export --without-hashes -f requirements.txt --only main \
        | /venv/bin/pip install -r /dev/stdin \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,7 @@ FROM python:3.11-alpine AS builder
 ARG TARGETPLATFORM
 
 # Set up the build environment:
-ENV CRYPTOGRAPHY_VERSION=42.0.8 \
-    PIP_DEFAULT_TIMEOUT=100 \
+ENV PIP_DEFAULT_TIMEOUT=100 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PIP_NO_CACHE_DIR=1 \
     PIP_PREFER_BINARY=1 \
@@ -29,9 +28,7 @@ RUN apk add --no-cache \
 
 # Add poetry and build dependencies:
 COPY . .
-RUN printf "[global]\nextra-index-url=https://www.piwheels.org/simple\n" > /etc/pip.conf \
-    && pip install --upgrade pip \
-    && pip install cryptography==${CRYPTOGRAPHY_VERSION} \
+RUN pip install --upgrade pip \
     && pip install poetry==${POETRY_VERSION} \
     && python3 -m venv /venv
 RUN poetry export --without-hashes -f requirements.txt --only main \


### PR DESCRIPTION
**Describe what the PR does:**

This PR removes `armv6` and `armv7` as Docker targets. This library's dependencies are advancing beyond what these outdated architectures support.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [x] Update `README.md` with any new documentation.
