### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN apk add --no-cache \
 # Add poetry and build dependencies:
 COPY . .
 RUN pip install --upgrade pip \
-    && pip install poetry==${POETRY_VERSION} \
+    && pip install poetry==${POETRY_VERSION} "poetry-plugin-export"\
     && python3 -m venv /venv
 RUN poetry export --without-hashes -f requirements.txt --only main \
        | /venv/bin/pip install -r /dev/stdin \


### PR DESCRIPTION
Since poetry 2.x poetry export plugin is not installeb by default. Added it to pip install. Image builds now successfully.

**Describe what the PR does:**
add  "poetry-plugin-export"  to pip install in Dockerfile

**Does this fix a specific issue?**
YES: poetry export does not exist with poetry 2.1.2 without specifically installing it.

Fixes https://github.com/bachya/ecowitt2mqtt/issues/<ISSUE ID>

**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [x] Update `README.md` with any new documentation.
