### PR TITLE
Fixes HA WARNING message during startup. Defines default_entity_id based on platform and object_id. Removes deprecated object_id

### DIFF
--- a/ecowitt2mqtt/helpers/publisher/mqtt/hass.py
+++ b/ecowitt2mqtt/helpers/publisher/mqtt/hass.py
@@ -1,4 +1,4 @@
-"""Define MQTT publishing."""
+ƒ"""Define MQTT publishing."""
 
 # pylint: disable=unused-argument
 from __future__ import annotations
@@ -181,6 +181,7 @@ class HassDiscoveryInfo:
     device_class: str | None = None
     entity_category: str | None = None
     icon: str | None = None
+    object_id: str | None = None
     default_entity_id: str | None = None
     qos: int = 1
     state_class: str | None = None
@@ -518,7 +519,8 @@ class HomeAssistantDiscoveryPublisher(MqttPublisher):  # pylint: disable=too-few
         )
 
         if self._config.hass_entity_id_prefix:
-            discovery.default_entity_id = f"{self._config.hass_entity_id_prefix}_{payload_key}"
+            discovery.object_id = f"{self._config.hass_entity_id_prefix}_{payload_key}"
+            discovery.default_entity_id = f"{PLATFORM_MAP[data_point.data_type]}.{discovery.object_id}"
         if data_point.unit:
             discovery.unit_of_measurement = data_point.unit
 

--- a/ecowitt2mqtt/helpers/publisher/mqtt/hass.py
+++ b/ecowitt2mqtt/helpers/publisher/mqtt/hass.py
@@ -181,7 +181,7 @@ class HassDiscoveryInfo:
     device_class: str | None = None
     entity_category: str | None = None
     icon: str | None = None
-    object_id: str | None = None
+    default_entity_id: str | None = None
     qos: int = 1
     state_class: str | None = None
     unit_of_measurement: str | None = None
@@ -518,7 +518,7 @@ class HomeAssistantDiscoveryPublisher(MqttPublisher):  # pylint: disable=too-few
         )
 
         if self._config.hass_entity_id_prefix:
-            discovery.object_id = f"{self._config.hass_entity_id_prefix}_{payload_key}"
+            discovery.default_entity_id = f"{self._config.hass_entity_id_prefix}_{payload_key}"
         if data_point.unit:
             discovery.unit_of_measurement = data_point.unit
 

--- a/ecowitt2mqtt/helpers/publisher/mqtt/hass.py
+++ b/ecowitt2mqtt/helpers/publisher/mqtt/hass.py
@@ -181,7 +181,6 @@ class HassDiscoveryInfo:
     device_class: str | None = None
     entity_category: str | None = None
     icon: str | None = None
-    object_id: str | None = None
     default_entity_id: str | None = None
     qos: int = 1
     state_class: str | None = None
@@ -519,8 +518,7 @@ class HomeAssistantDiscoveryPublisher(MqttPublisher):  # pylint: disable=too-few
         )
 
         if self._config.hass_entity_id_prefix:
-            discovery.object_id = f"{self._config.hass_entity_id_prefix}_{payload_key}"
-            discovery.default_entity_id = f"{PLATFORM_MAP[data_point.data_type]}.{discovery.object_id}"
+            discovery.default_entity_id = f"{PLATFORM_MAP[data_point.data_type]}.{self._config.hass_entity_id_prefix}_{payload_key}"
         if data_point.unit:
             discovery.unit_of_measurement = data_point.unit
 


### PR DESCRIPTION
**Describe what the PR does:**

Fixes HA WARNING message during startup. Renames object_id with default_entity_id

**Does this fix a specific issue?**

Fixes https://github.com/bachya/ecowitt2mqtt/issues/1324

No new functionality added!

**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [x] Update `README.md` with any new documentation.
