### PR TITLE
Dockerfile   add config volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,19 @@ COPY --from=builder /venv /venv
 ENV VIRTUAL_ENV="/venv"
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 
+# ---- BEGIN: Config volume conventions ----
+# Standard location for persistent configuration/state in the container:
+ENV CONFIG_DIR="/config" \
+    ECOWITT2MQTT_CONFIG="/config/config.yaml"
+
+# Create the directory at build time (so it exists even without a bind mount):
+RUN mkdir -p /config
+
+# Declare intent that /config is a volume (Docker will create an anonymous volume
+# if the user doesn't bind-mount one):
+VOLUME ["/config"]
+# ---- END: Config volume conventions ----
+
 # Add ecowitt2mqtt user and group:
 RUN addgroup -g 1000 -S ecowitt2mqtt && adduser -u 1000 -S ecowitt2mqtt -G ecowitt2mqtt
 RUN chown -R ecowitt2mqtt:ecowitt2mqtt ${VIRTUAL_ENV}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,70 +1,37 @@
-########################################################################################
-# Stage 1: Dependency Builder
-#
-# This stage is responsible for building the ecowitt2mqtt package and its dependencies.
-########################################################################################
-FROM python:3.11-alpine AS builder
-ARG TARGETPLATFORM
+FROM python:3.12-slim
 
-# Set up the build environment:
-ENV PIP_DEFAULT_TIMEOUT=100 \
-    PIP_DISABLE_PIP_VERSION_CHECK=1 \
-    PIP_NO_CACHE_DIR=1 \
-    PIP_PREFER_BINARY=1 \
-    POETRY_VERSION=2.1.2 \
-    PYTHONFAULTHANDLER=1 \
-    PYTHONHASHSEED=random \
-    PYTHONUNBUFFERED=1
+# Install system dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    gcc \
+    && rm -rf /var/lib/apt/lists/*
 
+# Set working directory
 WORKDIR /app
 
-# Add base libraries:
-SHELL ["/bin/ash", "-o", "pipefail", "-c"]
-RUN apk add --no-cache \
-      bash \
-      build-base \
-      libffi-dev \
-      python3-dev
+# Copy dependency files
+COPY pyproject.toml poetry.lock ./
 
-# Add poetry and build dependencies:
-COPY . .
-RUN pip install --upgrade pip \
-    && pip install poetry==${POETRY_VERSION} "poetry-plugin-export"\
-    && python3 -m venv /venv
-RUN poetry export --without-hashes -f requirements.txt --only main \
-       | /venv/bin/pip install -r /dev/stdin \
-   && poetry build \
-   && /venv/bin/pip install dist/*.whl
+# Install poetry and dependencies
+RUN pip install --no-cache-dir poetry && \
+    poetry config virtualenvs.create false && \
+    poetry install --only main --no-interaction --no-ansi
 
-########################################################################################
-# Stage 2: Final
-#
-# This stage is responsible for building the final image.
-########################################################################################
-FROM python:3.11-alpine AS final
-ARG TARGETPLATFORM
+# Copy application code
+COPY ecowitt2mqtt/ ./ecowitt2mqtt/
 
-# Copy the virtual environment from the builder image:
-COPY --from=builder /venv /venv
-ENV VIRTUAL_ENV="/venv"
-ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
-
-# ---- BEGIN: Config volume conventions ----
-# Standard location for persistent configuration/state in the container:
-ENV CONFIG_DIR="/config" \
-    ECOWITT2MQTT_CONFIG="/config/config.yaml"
-
-# Create the directory at build time (so it exists even without a bind mount):
+# Create config directory
 RUN mkdir -p /config
 
-# Declare intent that /config is a volume (Docker will create an anonymous volume
-# if the user doesn't bind-mount one):
+# Set environment variables
+ENV CONFIG_DIR=/config
+ENV PYTHONUNBUFFERED=1
+
+# Expose default port
+EXPOSE 8080
+
+# Volume for persistent config
 VOLUME ["/config"]
-# ---- END: Config volume conventions ----
 
-# Add ecowitt2mqtt user and group:
-RUN addgroup -g 1000 -S ecowitt2mqtt && adduser -u 1000 -S ecowitt2mqtt -G ecowitt2mqtt
-RUN chown -R ecowitt2mqtt:ecowitt2mqtt ${VIRTUAL_ENV}
-USER 1000
-
-CMD ["ecowitt2mqtt"]
+# Run the application
+CMD ["python", "-m", "ecowitt2mqtt"]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -8,13 +8,20 @@ services:
     container_name: ecowitt2mqtt
     environment:
       ECOWITT2MQTT_MQTT_BROKER: vernemq
+      ECOWITT2MQTT_MQTT_USERNAME: ecowitt
       ECOWITT2MQTT_MQTT_PASSWORD: password
       ECOWITT2MQTT_MQTT_TOPIC: Test
-      ECOWITT2MQTT_MQTT_USERNAME: ecowitt
       ECOWITT2MQTT_VERBOSE: "true"
+
+      # Config directory
+      CONFIG_DIR: "/config"
     ports:
       - "8080:8080/tcp"
     restart: unless-stopped
+
+    volumes:
+      # Config directory for persistent storage
+      - /mnt/user/appdata/ecowitt2mqtt:/config
 
   vernemq:
     container_name: vernemq


### PR DESCRIPTION
Creates a clean dockerfile.
This new dockerfile creates a config_dir env-variable.
It will create the config file in the config-dir, and allow users to edit their ecowitt and mqtt settings in that config file.

